### PR TITLE
Update joblib dependency to at least 0.13.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     keras
     sparse
     tensorflow == 1.*
-    joblib
+    joblib >= 0.13.0
     numba != 0.42.1
 test_suite = econml.tests
 tests_require =


### PR DESCRIPTION
Pickling local objects doesn't work in versions of joblib prior to 0.13.0, which was breaking some of our code.