### PR TITLE
Pin matplotlib version to fix Python 3.5 builds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ test_suite = econml.tests
 tests_require =
     pytest    
     pytest-xdist
-    matplotlib
+    matplotlib < 3.1
     pandas
     jupyter
 ; TODO: remove matplotlib, pandas dependencies when cleaning up tests


### PR DESCRIPTION
Matplotlib 3.1 requires Python version >= 3.6; since we don't take a hard dependency on matplotlib (we only use it in tests) we should continue to use older versions so that we can still test against Python 3.5