### PR TITLE
Fix notebook condition in build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
           switch -Wildcard ($file) {
             "README.md" { Continue }
             "doc/*" { $docChanges = $true; Continue }
-            "notebook/*" { $nbChanges = $true; Continue }
+            "notebooks/*" { $nbChanges = $true; Continue }
             default { $codeChanges = $true; Continue }
           }
         }


### PR DESCRIPTION
We are currently incorrectly running all tasks as part of CI when there are only changes to the notebooks, instead of only running the notebook tests (which we'd rather do since notebook changes can't affect anything else).