### PR TITLE
Fixed a few typos in docs

### DIFF
--- a/doc/spec/api.rst
+++ b/doc/spec/api.rst
@@ -132,7 +132,7 @@ One particular prevalent assumption is that the outcome :math:`y` is linear in t
 
     T =~& f(X, W, Z, \eta)
 
-where :math:`\epsilon, \eta` are exogenous noise terms. Under such a linear response assumption we observe that the CATE and marginal CATE takes a special form of:
+where :math:`\epsilon, \eta` are exogenous noise terms. Under such a linear response assumption we observe that the CATE and marginal CATE take a special form of:
 
 .. math ::
 
@@ -176,7 +176,7 @@ Example Use of API
 Let us walk through a simple example of what one can achieve via the latter API
 even irrespective of the actual estimation method that is being used.
 
-Let us consider a hypothetical data generating process governed by the 
+Let us consider a hypothetical data generating process (DGP) governed by the 
 following equations:
 
 .. math ::
@@ -187,7 +187,7 @@ following equations:
     \end{align}
 
 
-Suppose that we have :math:`n` samples from this dgp. For instance, we could create these
+Suppose that we have :math:`n` samples from this DGP. For instance, we could create these
 samples with the following code:
 
 .. code-block:: python3

--- a/doc/spec/estimation/dml.rst
+++ b/doc/spec/estimation/dml.rst
@@ -204,7 +204,7 @@ One can also define a custom featurizer, as long as it supports the fit\_transfo
             
     est = DMLCateEstimator(model_y=sklearn.ensemble.RandomForestRegressor(), 
                             model_t=sklearn.ensemble.RandomForestRegressor(),
-                            featurizer=sklearn.preprocessing.LogFeatures())
+                            featurizer=LogFeatures())
     est.fit(y, T, X, W)
     a_hat = est.coef_
 
@@ -215,7 +215,7 @@ We can even create a Pipeline or Union of featurizers that will apply multiply f
 
     est = DMLCateEstimator(model_y=sklearn.ensemble.RandomForestRegressor(), 
                             model_t=sklearn.ensemble.RandomForestRegressor(),
-                            featurizer=Pipeline([('log', sklearn.preprocessing.LogFeatures()), 
+                            featurizer=Pipeline([('log', LogFeatures()), 
                                             ('poly', sklearn.preprocessing.PolynomialFeatures(degree=3))]))
     est.fit(y, T, X, W)
     a_hat = est.coef_
@@ -223,7 +223,7 @@ We can even create a Pipeline or Union of featurizers that will apply multiply f
 
 .. rubric:: Sparse Linear Models
 
-If we also want to assume that the nuisance models are sparse linear and use the elasticNet instead of the LassoCV, then we can simply call:
+If we also want to assume that the nuisance models are sparse linear and use the ElasticNet instead of the LassoCV, then we can simply call:
 
 .. code-block:: python3
     :caption: Sparse Linear Nuisance Models
@@ -254,7 +254,7 @@ Suppose that we believed our DGP looks as in the example used in the general sec
     Y =~& \gamma T^2 + \delta X T + \ldot{\zeta}{W} + \kappa + \epsilon \\
     T =~& \ldot{\alpha}{W}  + \eta
 
-Then we could fit such a model by. using polynomial features for :math:`Z` and expanding the treatment vector to contain also polynomial features:
+Then we could fit such a model by using polynomial features for :math:`Z` and expanding the treatment vector to contain also polynomial features:
 
 .. code-block:: python3
     :caption: Polynomial Treatments
@@ -268,7 +268,7 @@ Then we could fit such a model by. using polynomial features for :math:`Z` and e
     a_hat = est.sparse_coef_
     # entry j*d_T+i = j*2 + i of this vector contains the coefficient α_ij
 
-The latter would fit a slightly more general model effect model of the form:
+The latter would fit a slightly more general model of the form:
 
 .. math::
 
@@ -286,7 +286,7 @@ If one wants to enforce sparsity of the :math:`\alpha_{ij}` coefficients, then a
     est.fit(y, np.concatenate((T, T**2), axis=1), X, W)
 
 
-Alternatively, we can estimate the more constraint model by building augmented features :math:`XT` and not using any :math:`X` for heterogeneity:
+Alternatively, we can estimate the more constrained model by building augmented features :math:`XT` and not using any :math:`X` for heterogeneity:
 
 .. code-block:: python3
     :caption: Direct Composite Treatments
@@ -300,7 +300,7 @@ However, the latter would also orthogonalize :math:`X` on :math:`W`, which could
 Example Use Cases: Multiple Outcome, Multiple Treatments
 --------------------------------------------------------
 
-In settings like demand estimation, we might want to fit the demand of multiple products as a function of the price of each one of them, i.e. fit the matrix of cross price elasticities. The latter can be done, by simply setting as :math:`Y` to be the vector of demands and :math:`T` to be the vector of prices. Then we can recover the 
+In settings like demand estimation, we might want to fit the demand of multiple products as a function of the price of each one of them, i.e. fit the matrix of cross price elasticities. The latter can be done, by simply setting :math:`Y` to be the vector of demands and :math:`T` to be the vector of prices. Then we can recover the 
 matrix of cross price elasticities as:
 
 .. code-block:: python3

--- a/doc/spec/estimation/forest.rst
+++ b/doc/spec/estimation/forest.rst
@@ -25,10 +25,10 @@ approach since we essentially perform a residual outcome on residual treatment r
 of running an arbitrary regression we perform a non-parametric local weighted regression. The kernel :math:`K(X_i, x)`
 is a similarity metric that is calculated by building a random forest with a causal criterion. This 
 criterion is a slight modification of the criterion used in generalized random forests [Athey2019]_ and 
-causal forests [Wager2018]_, so as to incorporated residualization when calculating the score of each candidate
+causal forests [Wager2018]_, so as to incorporate residualization when calculating the score of each candidate
 split.
 
-The method splits the data and performs cross-fitting: i.e. fit the
+The method splits the data and performs cross-fitting: i.e. fits the
 conditional expectation models on the first half and predicts the quantities on the second half and vice versa. 
 Subsequently estimates :math:`\theta(x)` on all the data. 
 
@@ -131,7 +131,7 @@ Similarly, we can call :py:class:`~econml.ortho_forest.DiscreteTreatmentOrthoFor
      [1.2]]
 
 Let's now look at a more involved example with a high-dimensional set of confounders :math:`W`
-and with more realistic noisy data. In this case we can just use the default Parameters
+and with more realistic noisy data. In this case we can just use the default parameters
 of the class, which specify the use of the :py:class:`~sklearn.linear_model.LassoCV` for 
 both the treatment and the outcome regressions, in the case of continuous treatments.
 

--- a/doc/spec/motivation.rst
+++ b/doc/spec/motivation.rst
@@ -8,7 +8,7 @@ of the treated sample? For instance, this problem arises in personalized pricing
 price discount on the demand as a function of characteristics of the consumer. Similarly it arises in medical trials where the 
 goal is to estimate the effect of a drug treatment on the clinical response of a patient as a function of patient 
 characteristics. In many such settings we have an abundance of observational data, where the treatment was chosen via 
-some unknown policy and the ability to run control A/B tests is limited. 
+some unknown policy and the ability to run A/B tests is limited. 
 
 The EconML package implements recent techniques in the literature at the intersection of econometrics and machine
 learning that tackle the problem of heterogeneous treatment effect estimation via machine learning based approaches.
@@ -35,7 +35,7 @@ Customer Targeting
 ------------------
 
 An important problem in modern business analytics is building automated tools to prioritize customer
-acquisition and personalize customer interactions for increase in sales and revenue. Typically businesses
+acquisition and personalize customer interactions to increase sales and revenue. Typically businesses
 will offer personalize incentives to customers to increase spend or increase the level of
 engagement via more human resources. Any such personalized intervention corresponds to a monetary
 investment and the main question that business analytics are called to answer is: what is the return
@@ -65,7 +65,7 @@ Stratification in Clinical Trials
 ----------------------------------------
 
 Which patients should be selected for a clinical trial? If we want to demonstrate
-that a clinical treatment has an effect on at least some subset of a population then
+that a clinical treatment has an effect on at least some subset of a population, then
 fully randomized clinical trials are inappropriate as they will solely estimate
 average effects. Using heterogeneous treatment effect techniques, we can use
 observational data to come up with estimates of these effects and identify
@@ -75,10 +75,10 @@ treatment effects.
 Learning Click-Through-Rates
 ----------------------------
 
-In the design of a page layouts and more importantly in ad placement, it is important
+In the design of a page layout and more importantly in ad placement, it is important
 to understand the click-through-rate of page components (e.g. ads) on different positions
 of a page. Even though the modern approach is to run multiple A/B tests, when such
-page component involve revenue considerations (such as ad placement), then observational
+page components involve revenue considerations (such as ad placement), then observational
 data can help guide correct A/B tests to run. Heterogeneous treatment effect estimation
 can provide estimates of the click-through-rate of page components from
 observational data. In this setting, the treatment is simply whether the component is


### PR DESCRIPTION
Notes on a couple of the changes:
- In `motivation.rst` I changed "**for increase in** sales and revenue" to "**to increase** sales and revenue", but maybe that should be "**for increased** sales and revenue"?
- In `dml.rst` I dropped `sklearn.preprocessing` from "`LogFeatures`" in a couple places, because it looks like that's a custom class, not sklearn's.
