### PR TITLE
Enable tests even when linting fails

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,6 +132,7 @@ jobs:
 
         - script: 'python setup.py pytest'
           displayName: 'Unit tests'
+          condition: succeededOrFailed()
           env:
             PYTEST_ADDOPTS: '-m "not notebook"'
             COVERAGE_PROCESS_START: 'setup.cfg'


### PR DESCRIPTION
We should run tests regardless of whether linting succeeds; the author will need to fix both types of issues either way, but this way they don't need to run multiple builds to see all issues.