### PR TITLE
Clean up cross references

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -6,6 +6,7 @@ Public Module Reference
 
     econml.bootstrap
     econml.cate_estimator
+    econml.causal_tree
     econml.deepiv
     econml.dgp
     econml.dml

--- a/doc/spec/estimation/dml.rst
+++ b/doc/spec/estimation/dml.rst
@@ -197,7 +197,7 @@ One can also define a custom featurizer, as long as it supports the fit\_transfo
 .. code-block:: python3
     :caption: Custom Featurizer
 
-    class LogFeatures(object):
+    class LogFeatures:
         ''' Augments the features with logarithmic features and returns the augmented structure'''
         def fit_transform(self, X):
             return np.concatenate((X, np.log(X)), axis=1)

--- a/econml/_ortho_learner.py
+++ b/econml/_ortho_learner.py
@@ -222,10 +222,10 @@ class _OrthoLearner(TreatmentExpansionMixin, LinearCateEstimator):
                                    sample_weight=sample_weight, sample_var=sample_var)
 
         In fact we allow for the model method signatures to skip any of the keyword arguments
-        as long as the class is always called with the omitted keyword argument set to `None`.
+        as long as the class is always called with the omitted keyword argument set to ``None``.
         This can be enforced in child classes by re-implementing the fit and the various effect
-        methods. If `discrete_treatment=True`, then the input `T` to both above calls will be the
-        one-hot encoding of the original input `T`, excluding the first column of the one-hot.
+        methods. If ``discrete_treatment=True``, then the input ``T`` to both above calls will be the
+        one-hot encoding of the original input ``T``, excluding the first column of the one-hot.
 
     model_final: estimator for fitting the response residuals to the features and treatment residuals
         Must implement `fit` and `predict` methods that must have signatures::
@@ -236,10 +236,11 @@ class _OrthoLearner(TreatmentExpansionMixin, LinearCateEstimator):
 
         Predict, should just take the features X and return the constant marginal effect. In fact we allow for the
         model method signatures to skip any of the keyword arguments as long as the class is always called with the
-        omitted keyword argument set to `None`. Moreover, the predict function of the final model can take no argument
-        if the class is always called with `X=None`. This can be enforced in child classes by re-implementing the fit
-        and the various effect methods. If `discrete_treatment=True`, then the input `T` to both above calls will be
-        the one-hot encoding of the original input `T`, excluding the first column of the one-hot.
+        omitted keyword argument set to ``None``. Moreover, the predict function of the final model can take no
+        argument if the class is always called with ``X=None``. This can be enforced in child classes by
+        re-implementing the fit and the various effect methods. If ``discrete_treatment=True``, then the input ``T``
+        to both above calls will be the one-hot encoding of the original input ``T``, excluding the first column of
+        the one-hot.
 
     discrete_treatment: bool
         Whether the treatment values should be treated as categorical, rather than continuous, quantities
@@ -265,7 +266,7 @@ class _OrthoLearner(TreatmentExpansionMixin, LinearCateEstimator):
         If int, random_state is the seed used by the random number generator;
         If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
         If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
-        by `np.random`.
+        by :mod:`np.random<numpy.random>`.
 
     Examples
     --------
@@ -462,9 +463,9 @@ class _OrthoLearner(TreatmentExpansionMixin, LinearCateEstimator):
             Weights for each samples
         sample_var: optional (n,) vector or None (Default=None)
             Sample variance for each sample
-        inference: string, `Inference` instance, or None
+        inference: string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`).
+            (or an instance of :class:`.BootstrapInference`).
 
         Returns
         -------
@@ -550,7 +551,7 @@ class _OrthoLearner(TreatmentExpansionMixin, LinearCateEstimator):
         Then calls the score function of the model_final and returns the calculated score.
         The model_final model must have a score method.
 
-        If model_final does not have a score method, then it raises an `AttributeError`
+        If model_final does not have a score method, then it raises an :exc:`.AttributeError`
 
         Parameters
         ----------

--- a/econml/_rlearner.py
+++ b/econml/_rlearner.py
@@ -99,7 +99,7 @@ class _RLearner(_OrthoLearner):
         If int, random_state is the seed used by the random number generator;
         If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
         If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
-        by `np.random`.
+        by :mod:`np.random<numpy.random>`.
 
     Examples
     --------
@@ -267,9 +267,9 @@ class _RLearner(_OrthoLearner):
             Weights for each samples
         sample_var: optional(n,) vector or None (Default=None)
             Sample variance for each sample
-        inference: string, `Inference` instance, or None
+        inference: string,:class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`).
+            (or an instance of:class:`.BootstrapInference`).
 
         Returns
         -------
@@ -285,7 +285,7 @@ class _RLearner(_OrthoLearner):
         It uses the mean prediction of the models fitted by the different crossfit folds.
         Then calculates the MSE of the final residual Y on residual T regression.
 
-        If model_final does not have a score method, then it raises an `AttributeError`
+        If model_final does not have a score method, then it raises an :exc:`.AttributeError`
 
         Parameters
         ----------

--- a/econml/bootstrap.py
+++ b/econml/bootstrap.py
@@ -7,7 +7,7 @@ from joblib import Parallel, delayed
 from sklearn.base import clone
 
 
-class BootstrapEstimator(object):
+class BootstrapEstimator:
     """Estimator that uses bootstrap sampling to wrap an existing estimator.
 
     This estimator provides a `fit` method with the same signature as the wrapped estimator.
@@ -38,12 +38,12 @@ class BootstrapEstimator(object):
 
     compute_means : bool, default: True
         Whether to pass calls through to the underlying collection and return the mean.  Setting this
-        to `False` can avoid ambiguities if the wrapped object itself has method names with an `_interval` suffix.
+        to ``False`` can avoid ambiguities if the wrapped object itself has method names with an `_interval` suffix.
 
     prefer_wrapped: bool, default: False
         In case a method ending in '_interval' exists on the wrapped object, whether
         that should be preferred (meaning this wrapper will compute the mean of it).
-        This option only affects behavior if `compute_means` is set to `True`.
+        This option only affects behavior if `compute_means` is set to ``True``.
     """
 
     def __init__(self, wrapped, n_bootstrap_samples=1000, n_jobs=None, compute_means=True, prefer_wrapped=False):

--- a/econml/cate_estimator.py
+++ b/econml/cate_estimator.py
@@ -19,9 +19,9 @@ class BaseCateEstimator(metaclass=abc.ABCMeta):
 
     def _get_inference_options(self):
         """
-        Produce a dictionary mapping string names to `Inference` types.
+        Produce a dictionary mapping string names to :class:`.Inference` types.
 
-        This is used by the `fit` method when a string is passed rather than an `Inference` type.
+        This is used by the :meth:`fit` method when a string is passed rather than an :class:`.Inference` type.
         """
         return {'bootstrap': BootstrapInference}
 
@@ -66,9 +66,9 @@ class BaseCateEstimator(metaclass=abc.ABCMeta):
             Controls for each sample
         Z: optional (n, d_z) matrix
             Instruments for each sample
-        inference: optional string, `Inference` instance, or None
-            Method for performing inference.  All estimators support 'bootstrap'
-            (or an instance of `BootstrapInference`), some support other methods as well.
+        inference: optional string, :class:`.Inference` instance, or None
+            Method for performing inference.  All estimators support ``'bootstrap'``
+            (or an instance of :class:`.BootstrapInference`), some support other methods as well.
 
         Returns
         -------

--- a/econml/causal_tree.py
+++ b/econml/causal_tree.py
@@ -3,8 +3,8 @@
 
 """Basic tree utilities and methods.
 
-Class `CausalTree` is the base estimator for the Orthogonal Random Forest, whereas
-class `Node` represents the core unit of the `CausalTree` class.
+Class :class:`CausalTree` is the base estimator for the Orthogonal Random Forest, whereas
+class :class:`Node` represents the core unit of the :class:`CausalTree` class.
 """
 
 import numpy as np
@@ -15,7 +15,7 @@ import scipy.special
 
 
 class Node:
-    """Building block of `CausalTree` class.
+    """Building block of :class:`CausalTree` class.
 
     Parameters
     ----------
@@ -54,7 +54,7 @@ class Node:
 
 
 class CausalTree:
-    """Base class for growing an `OrthoTree`.
+    """Base class for growing an OrthoForest.
 
     Parameters
     ----------
@@ -88,11 +88,11 @@ class CausalTree:
         With the default value we guarantee that each child of a split contains
         at least 20% and at most 80% of the data of the parent node.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
+        If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
+        by :mod:`np.random<numpy.random>`.
     """
 
     def __init__(self,

--- a/econml/data/dgps.py
+++ b/econml/data/dgps.py
@@ -14,11 +14,11 @@ def ihdp_surface_A(random_state=None):
 
         Parameters
         ----------
-        random_state : int, RandomState instance or None, optional (default=None)
+        random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional (default=None)
             If int, random_state is the seed used by the random number generator;
-            If RandomState instance, random_state is the random number generator;
-            If None, the random number generator is the RandomState instance used
-            by `np.random`.
+            If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
+            If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
+            by :mod:`np.random<numpy.random>`.
 
         Returns
         -------
@@ -48,11 +48,11 @@ def ihdp_surface_B(random_state=None):
 
         Parameters
         ----------
-        random_state : int, RandomState instance or None, optional (default=None)
+        random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional (default=None)
             If int, random_state is the seed used by the random number generator;
-            If RandomState instance, random_state is the random number generator;
-            If None, the random number generator is the RandomState instance used
-            by `np.random`.
+            If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
+            If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
+            by :mod:`np.random<numpy.random>`.
 
         Returns
         -------

--- a/econml/deepiv.py
+++ b/econml/deepiv.py
@@ -303,9 +303,9 @@ class DeepIVEstimator(BaseCateEstimator):
             Features for each sample
         Z: (n × d_z) matrix
             Instruments for each sample
-        inference: string, `Inference` instance, or None
+        inference: string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`)
+            (or an instance of :class:`.BootstrapInference`)
 
         Returns
         -------

--- a/econml/dml.py
+++ b/econml/dml.py
@@ -78,7 +78,7 @@ class DMLCateEstimator(_RLearner):
         If int, random_state is the seed used by the random number generator;
         If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
         If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
-        by `np.random`.
+        by :mod:`np.random<numpy.random>`.
     """
 
     def __init__(self,
@@ -246,7 +246,7 @@ class LinearDMLCateEstimator(StatsModelsCateEstimatorMixin, DMLCateEstimator):
         If int, random_state is the seed used by the random number generator;
         If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
         If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
-        by `np.random`.
+        by :mod:`np.random<numpy.random>`.
 
     """
 
@@ -283,7 +283,7 @@ class LinearDMLCateEstimator(StatsModelsCateEstimatorMixin, DMLCateEstimator):
             Controls for each sample
         sample_weight: optional (n,) vector
             Weights for each row
-        inference: string, `Inference` instance, or None
+        inference: string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
             (or an instance of :class:`.BootstrapInference`) and 'statsmodels'
             (or an instance of :class:`.StatsModelsInference`)
@@ -352,7 +352,7 @@ class SparseLinearDMLCateEstimator(DMLCateEstimator):
         If int, random_state is the seed used by the random number generator;
         If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
         If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
-        by `np.random`.
+        by :mod:`np.random<numpy.random>`.
     """
 
     def __init__(self,
@@ -415,7 +415,7 @@ class KernelDMLCateEstimator(LinearDMLCateEstimator):
         If int, random_state is the seed used by the random number generator;
         If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
         If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
-        by `np.random`.
+        by :mod:`np.random<numpy.random>`.
     """
 
     def __init__(self, model_y=LassoCV(), model_t=LassoCV(),

--- a/econml/drlearner.py
+++ b/econml/drlearner.py
@@ -142,7 +142,7 @@ class DRLearner(_OrthoLearner):
         If int, random_state is the seed used by the random number generator;
         If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
         If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
-        by `np.random`.
+        by :mod:`np.random<numpy.random>`.
 
     Examples
     --------
@@ -351,9 +351,9 @@ class DRLearner(_OrthoLearner):
             Weights for each samples
         sample_var: optional(n,) vector or None (Default=None)
             Sample variance for each sample
-        inference: string, `Inference` instance, or None
+        inference: string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`).
+            (or an instance of :class:`.BootstrapInference`).
 
         Returns
         -------
@@ -369,7 +369,7 @@ class DRLearner(_OrthoLearner):
         It uses the mean prediction of the models fitted by the different crossfit folds.
         Then calculates the MSE of the final residual Y on residual T regression.
 
-        If model_final does not have a score method, then it raises an `AttributeError`
+        If model_final does not have a score method, then it raises an :exc:`.AttributeError`
 
         Parameters
         ----------
@@ -559,7 +559,7 @@ class LinearDRLearner(StatsModelsCateEstimatorDiscreteMixin, DRLearner):
         If int, random_state is the seed used by the random number generator;
         If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
         If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
-        by `np.random`.
+        by :mod:`np.random<numpy.random>`.
 
     Examples
     --------
@@ -637,10 +637,10 @@ class LinearDRLearner(StatsModelsCateEstimatorDiscreteMixin, DRLearner):
             Weights for each samples
         sample_var: optional(n,) vector or None (Default=None)
             Sample variance for each sample
-        inference: string, `Inference` instance, or None
-            Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`) and 'statsmodels'
-            (or an instance of `StatsModelsInferenceDiscrete`).
+        inference: string, :class:`.Inference` instance, or None
+            Method for performing inference.  This estimator supports ``'bootstrap'``
+            (or an instance of :class:`.BootstrapInference`) and ``'statsmodels'``
+            (or an instance of :class:`.StatsModelsInferenceDiscrete`).
 
         Returns
         -------

--- a/econml/inference.py
+++ b/econml/inference.py
@@ -67,7 +67,7 @@ class StatsModelsInference(Inference):
     This class can be used for inference by the LinearDMLCateEstimator.
 
     Any estimator that supports this method of inference must implement a `statsmodels`
-    property that returns a `StatsModelsLinearRegression` instance and a `featurizer` property that returns an
+    property that returns a :class:`.StatsModelsLinearRegression` instance and a `featurizer` property that returns an
     preprocessing featurizer for the X variable.
 
     Parameters
@@ -131,9 +131,9 @@ class StatsModelsInferenceDiscrete(Inference):
 
     This class can be used for inference by the LinearDRLearner.
 
-    Any estimator that supports this method of inference must implement a `statsmodels`
-    property that returns a `StatsModelsLinearRegression` instance, a `statsmodels_fitted` property
-    which is a list of the fitted `StatsModelsLinearRegression` instances, fitted by the estimator for each
+    Any estimator that supports this method of inference must implement a ``statsmodels``
+    property that returns a :class:`.StatsModelsLinearRegression` instance, a ``statsmodels_fitted`` property
+    which is a list of the fitted :class:`.StatsModelsLinearRegression` instances, fitted by the estimator for each
     discrete treatment target and a `featurizer` property that returns an
     preprocessing featurizer for the X variable.
 

--- a/econml/metalearners.py
+++ b/econml/metalearners.py
@@ -57,9 +57,9 @@ class TLearner(TreatmentExpansionMixin, LinearCateEstimator):
         X : array-like, shape (n, d_x)
             Feature vector that captures heterogeneity.
 
-        inference : string, `Inference` instance, or None
+        inference : string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`)
+            (or an instance of :class:`.BootstrapInference`)
 
         Returns
         -------
@@ -140,9 +140,9 @@ class SLearner(TreatmentExpansionMixin, LinearCateEstimator):
         X : array-like, shape (n, d_x), optional
             Feature vector that captures heterogeneity.
 
-        inference: string, `Inference` instance, or None
+        inference: string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`)
+            (or an instance of :class:`.BootstrapInference`)
 
         Returns
         -------
@@ -241,9 +241,9 @@ class XLearner(TreatmentExpansionMixin, LinearCateEstimator):
         X : array-like, shape (n, d_x)
             Feature vector that captures heterogeneity.
 
-        inference : string, `Inference` instance, or None
+        inference : string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`)
+            (or an instance of :class:`.BootstrapInference`)
 
         Returns
         -------
@@ -361,9 +361,9 @@ class DomainAdaptationLearner(TreatmentExpansionMixin, LinearCateEstimator):
         X : array-like, shape (n, d_x)
             Feature vector that captures heterogeneity.
 
-        inference : string, `Inference` instance, or None
+        inference : string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`)
+            (or an instance of :class:`.BootstrapInference`)
 
         Returns
         -------

--- a/econml/ortho_forest.py
+++ b/econml/ortho_forest.py
@@ -11,10 +11,10 @@ effect heterogeneity.
 
 This file consists of classes that implement the following variants of the ORF method:
 
-- The `ContinuousTreatmentOrthoForest`, a two-forest approach for learning continuous treatment effects
+- The :class:`ContinuousTreatmentOrthoForest`, a two-forest approach for learning continuous treatment effects
   using kernel two stage estimation.
 
-- The `DiscreteTreatmentOrthoForest`, a two-forest approach for learning discrete treatment effects
+- The :class:`DiscreteTreatmentOrthoForest`, a two-forest approach for learning discrete treatment effects
   using kernel two stage estimation.
 
 For more details on these methods, see our paper [Oprescu2019]_.
@@ -122,7 +122,7 @@ def _group_cross_fit(model_instance, X, y, t, split_indices, sample_weight=None,
 
 
 class BaseOrthoForest(TreatmentExpansionMixin, LinearCateEstimator):
-    """Base class for the `ContinuousTreatmentOrthoForest` and `DiscreteTreatmentOrthoForest`."""
+    """Base class for the :class:`ContinuousTreatmentOrthoForest` and :class:`DiscreteTreatmentOrthoForest`."""
 
     def __init__(self,
                  nuisance_estimator,
@@ -177,9 +177,9 @@ class BaseOrthoForest(TreatmentExpansionMixin, LinearCateEstimator):
         W : array-like, shape (n, d_w) or None (default=None)
             High-dimensional controls.
 
-        inference: string, `Inference` instance, or None
+        inference: string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`)
+            (or an instance of :class:`.BootstrapInference`)
 
         Returns
         -------
@@ -354,24 +354,24 @@ class ContinuousTreatmentOrthoForest(BaseOrthoForest):
 
     model_T_final : estimator, optional (default=None)
         The estimator for residualizing the treatment at prediction time. Must implement
-        `fit` and `predict` methods. If parameter is set to `None`, it defaults to the
+        `fit` and `predict` methods. If parameter is set to ``None``, it defaults to the
         value of `model_T` parameter.
 
     model_Y_final : estimator, optional (default=None)
         The estimator for residualizing the outcome at prediction time. Must implement
-        `fit` and `predict` methods. If parameter is set to `None`, it defaults to the
+        `fit` and `predict` methods. If parameter is set to ``None``, it defaults to the
         value of `model_Y` parameter.
 
     n_jobs : int, optional (default=-1)
-        The number of jobs to run in parallel for both `fit` and `predict`.
-        ``-1`` means using all processors. Since `OrthoForest` methods are
+        The number of jobs to run in parallel for both :meth:`fit` and :meth:`effect`.
+        ``-1`` means using all processors. Since OrthoForest methods are
         computationally heavy, it is recommended to set `n_jobs` to -1.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
+        If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
+        by :mod:`np.random<numpy.random>`.
 
     """
 
@@ -578,25 +578,25 @@ class DiscreteTreatmentOrthoForest(BaseOrthoForest):
     propensity_model_final : estimator, optional (default=None)
         Model for estimating propensity of treatment at at prediction time.
         Will be trained on features and controls (concatenated). Must implement `fit` and `predict_proba` methods.
-        If parameter is set to `None`, it defaults to the value of `propensity_model` parameter.
+        If parameter is set to ``None``, it defaults to the value of `propensity_model` parameter.
 
     model_Y_final : estimator, optional (default=None)
         Estimator for learning potential outcomes at prediction time.
         Will be trained on features, controls and one hot encoded treatments (concatenated).
         If different models per treatment arm are desired, see the :py:class:`~econml.utilities.MultiModelWrapper`
         helper class. The model(s) must implement `fit` and `predict` methods.
-        If parameter is set to `None`, it defaults to the value of `model_Y` parameter.
+        If parameter is set to ``None``, it defaults to the value of `model_Y` parameter.
 
     n_jobs : int, optional (default=-1)
-        The number of jobs to run in parallel for both `fit` and `predict`.
-        ``-1`` means using all processors. Since `OrthoForest` methods are
+        The number of jobs to run in parallel for both :meth:`fit` and :meth:`effect`.
+        ``-1`` means using all processors. Since OrthoForest methods are
         computationally heavy, it is recommended to set `n_jobs` to -1.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
+        If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
+        by :mod:`np.random<numpy.random>`.
 
 
     """
@@ -669,9 +669,9 @@ class DiscreteTreatmentOrthoForest(BaseOrthoForest):
         W : array-like, shape (n, d_w) or None (default=None)
             High-dimensional controls.
 
-        inference: string, `Inference` instance, or None
+        inference: string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`)
+            (or an instance of :class:`.BootstrapInference`)
 
         Returns
         -------

--- a/econml/selective_regularization.py
+++ b/econml/selective_regularization.py
@@ -10,7 +10,7 @@ import scipy.sparse as sp
 from itertools import product
 
 
-class SelectiveElasticNet(object):
+class SelectiveElasticNet:
     """
     Estimator that allows L1 and L2 penalties on a subset of the features of a linear model.
 

--- a/econml/sklearn_extensions/linear_model.py
+++ b/econml/sklearn_extensions/linear_model.py
@@ -153,13 +153,13 @@ class WeightedLasso(WeightedModelMixin, Lasso):
     positive : bool, optional
         When set to ``True``, forces the coefficients to be positive.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
-        'random'.
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection='random'``.
 
     selection : str, default 'cyclic'
         If set to 'random', a random coefficient is updated every iteration
@@ -251,13 +251,13 @@ class WeightedMultiTaskLasso(WeightedModelMixin, MultiTaskLasso):
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
-        'random'.
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection='random'``.
 
     selection : str, default 'cyclic'
         If set to 'random', a random coefficient is updated every iteration
@@ -364,13 +364,13 @@ class WeightedLassoCV(WeightedModelMixin, LassoCV):
     positive : bool, optional
         If positive, restrict regression coefficients to be positive
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
-        'random'.
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection='random'``.
 
     selection : str, default 'cyclic'
         If set to 'random', a random coefficient is updated every iteration
@@ -467,13 +467,13 @@ class WeightedMultiTaskLassoCV(WeightedModelMixin, MultiTaskLassoCV):
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
-        'random'
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection='random'``.
 
     selection : str, default 'cyclic'
         If set to 'random', a random coefficient is updated every iteration
@@ -565,13 +565,13 @@ class DebiasedLasso(WeightedLasso):
     positive : bool, optional
         When set to ``True``, forces the coefficients to be positive.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
-        'random'.
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection='random'``.
 
     selection : str, default 'cyclic'
         If set to 'random', a random coefficient is updated every iteration
@@ -839,13 +839,13 @@ class MultiOutputDebiasedLasso(MultiOutputRegressor):
     positive : bool, optional
         When set to ``True``, forces the coefficients to be positive.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
-        'random'.
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection='random'``.
 
     selection : str, default 'cyclic'
         If set to 'random', a random coefficient is updated every iteration

--- a/econml/sklearn_extensions/model_selection.py
+++ b/econml/sklearn_extensions/model_selection.py
@@ -86,11 +86,11 @@ class WeightedKFold:
     shuffle : boolean, optional
         Whether to shuffle the data before splitting into batches.
 
-    random_state : int, RandomState instance or None, optional, default=None
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default=None
         If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``shuffle`` == True.
+        If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
+        If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
+        by :mod:`np.random<numpy.random>`. Used when ``shuffle`` == True.
     """
 
     def __init__(self, n_splits=3, n_trials=10, shuffle=False, random_state=None):
@@ -167,11 +167,11 @@ class WeightedStratifiedKFold(WeightedKFold):
     shuffle : boolean, optional
         Whether to shuffle the data before splitting into batches.
 
-    random_state : int, RandomState instance or None, optional, default=None
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default=None
         If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``shuffle`` == True.
+        If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
+        If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
+        by :mod:`np.random<numpy.random>`. Used when ``shuffle`` == True.
     """
 
     def split(self, X, y, sample_weight=None):

--- a/econml/two_stage_least_squares.py
+++ b/econml/two_stage_least_squares.py
@@ -148,9 +148,9 @@ class NonparametricTwoStageLeastSquares(BaseCateEstimator):
             Controls for each sample
         Z: optional(n × d_z) matrix
             Instruments for each sample
-        inference: string, `Inference` instance, or None
+        inference: string, :class:`.Inference` instance, or None
             Method for performing inference.  This estimator supports 'bootstrap'
-            (or an instance of `BootstrapInference`)
+            (or an instance of :class:`.BootstrapInference`)
 
         Returns
         -------

--- a/econml/utilities.py
+++ b/econml/utilities.py
@@ -664,7 +664,7 @@ def einsum_sparse(subscripts, *arrs):
                   [arrs[indMap[c][0][0]].shape[indMap[c][0][1]] for c in outputs])
 
 
-class WeightedModelWrapper(object):
+class WeightedModelWrapper:
     """Helper class for assiging weights to models without this option.
 
     Parameters
@@ -737,8 +737,685 @@ class WeightedModelWrapper(object):
         return X[data_indices], y[data_indices]
 
 
-class MultiModelWrapper(object):
-    """Helper class for training different models for each treatment.
+def _fit_weighted_linear_model(self, class_name, X, y, sample_weight, check_input=None):
+    # Convert X, y into numpy arrays
+    X, y = check_X_y(X, y, y_numeric=True, multi_output=True)
+    # Define fit parameters
+    fit_params = {'X': X, 'y': y}
+    # Some algorithms doen't have a check_input option
+    if check_input is not None:
+        fit_params['check_input'] = check_input
+
+    if sample_weight is not None:
+        # Check weights array
+        if np.atleast_1d(sample_weight).ndim > 1:
+            # Check that weights are size-compatible
+            raise ValueError("Sample weights must be 1D array or scalar")
+        if np.ndim(sample_weight) == 0:
+            sample_weight = np.repeat(sample_weight, X.shape[0])
+        else:
+            sample_weight = check_array(sample_weight, ensure_2d=False, allow_nd=False)
+            if sample_weight.shape[0] != X.shape[0]:
+                raise ValueError(
+                    "Found array with {0} sample(s) while {1} samples were expected.".format(
+                        sample_weight.shape[0], X.shape[0])
+                )
+
+        # Normalize inputs
+        X, y, X_offset, y_offset, X_scale = self._preprocess_data(
+            X, y, fit_intercept=self.fit_intercept, normalize=False,
+            copy=self.copy_X, check_input=check_input if check_input is not None else True,
+            sample_weight=sample_weight, return_mean=True)
+        # Weight inputs
+        normalized_weights = X.shape[0] * sample_weight / np.sum(sample_weight)
+        sqrt_weights = np.sqrt(normalized_weights)
+        weight_mat = np.diag(sqrt_weights)
+        X_weighted = np.matmul(weight_mat, X)
+        y_weighted = np.matmul(weight_mat, y)
+        fit_params['X'] = X_weighted
+        fit_params['y'] = y_weighted
+        if self.fit_intercept:
+            # Fit base class without intercept
+            self.fit_intercept = False
+            # Fit Lasso
+            super(class_name, self).fit(**fit_params)
+            # Reset intercept
+            self.fit_intercept = True
+            # The intercept is not calculated properly due the sqrt(weights) factor
+            # so it must be recomputed
+            self._set_intercept(X_offset, y_offset, X_scale)
+        else:
+            super(class_name, self).fit(**fit_params)
+    else:
+        # Fit lasso without weights
+        super(class_name, self).fit(**fit_params)
+
+
+def _split_weighted_sample(self, X, y, sample_weight, is_stratified=False):
+    if is_stratified:
+        kfold_model = StratifiedKFold(n_splits=self.n_splits, shuffle=self.shuffle,
+                                      random_state=self.random_state)
+    else:
+        kfold_model = KFold(n_splits=self.n_splits, shuffle=self.shuffle,
+                            random_state=self.random_state)
+    if sample_weight is None:
+        return kfold_model.split(X, y)
+    weights_sum = np.sum(sample_weight)
+    max_deviations = []
+    all_splits = []
+    for i in range(self.n_trials + 1):
+        splits = [test for (train, test) in list(kfold_model.split(X, y))]
+        weight_fracs = np.array([np.sum(sample_weight[split]) / weights_sum for split in splits])
+        if np.all(weight_fracs > .95 / self.n_splits):
+            # Found a good split, return.
+            return self._get_folds_from_splits(splits, X.shape[0])
+        # Record all splits in case the stratification by weight yeilds a worse partition
+        all_splits.append(splits)
+        max_deviation = np.abs(weight_fracs - 1 / self.n_splits)
+        max_deviations.append(max_deviation)
+        # Reseed random generator and try again
+        kfold_model.shuffle = True
+        kfold_model.random_state = None
+
+    # If KFold fails after n_trials, we try the next best thing: stratifying by weight groups
+    warnings.warn("The KFold algorithm failed to find a weight-balanced partition after {n_trials} trials." +
+                  " Falling back on a weight stratification algorithm.".format(n_trials=self.n_trials), UserWarning)
+    if is_stratified:
+        stratified_weight_splits = [[]] * self.n_splits
+        for y_unique in np.unique(y.flatten()):
+            class_inds = np.argwhere(y == y_unique).flatten()
+            class_splits = self._get_splits_from_weight_stratification(sample_weight[class_inds])
+            stratified_weight_splits = [split + list(class_inds[class_split]) for split, class_split in zip(
+                stratified_weight_splits, class_splits)]
+    else:
+        stratified_weight_splits = self._get_splits_from_weight_stratification(sample_weight)
+    weight_fracs = np.array([np.sum(sample_weight[split]) / weights_sum for split in stratified_weight_splits])
+    if np.all(weight_fracs > .95 / self.n_splits):
+        # Found a good split, return.
+        return self._get_folds_from_splits(stratified_weight_splits, X.shape[0])
+    else:
+        # Did not find a good split
+        # Record the devaiation for the weight-stratified split to compare with KFold splits
+        all_splits.append(stratified_weight_splits)
+        max_deviation = np.abs(weight_fracs - 1 / self.n_splits)
+        max_deviations.append(max_deviation)
+    # Return most weight-balanced partition
+    min_deviation_index = np.argmin(max_deviations)
+    return self._get_folds_from_splits(all_splits[min_deviation_index], X.shape[0])
+
+
+def _weighted_check_cv(cv='warn', y=None, classifier=False):
+    if cv is None or cv == 'warn':
+        warnings.warn(CV_WARNING, FutureWarning)
+        cv = 3
+
+    if isinstance(cv, numbers.Integral):
+        if (classifier and (y is not None) and
+                (type_of_target(y) in ('binary', 'multiclass'))):
+            return WeightedStratifiedKFold(cv)
+        else:
+            return WeightedKFold(cv)
+
+    if not hasattr(cv, 'split') or isinstance(cv, str):
+        if not isinstance(cv, Iterable) or isinstance(cv, str):
+            raise ValueError("Expected cv as an integer, cross-validation "
+                             "object (from sklearn.model_selection) "
+                             "or an iterable. Got %s." % cv)
+        return _WeightedCVIterableWrapper(cv)
+
+    return cv  # New style cv objects are passed without any modification
+
+
+class _WeightedCVIterableWrapper(_CVIterableWrapper):
+    def __init__(self, cv):
+        super().__init__(cv)
+
+    def get_n_splits(self, X=None, y=None, groups=None, sample_weight=None):
+        return super().get_n_splits(self, X, y, groups)
+
+    def split(self, X=None, y=None, groups=None, sample_weight=None):
+        return super().split(X, y, groups)
+
+
+class WeightedLasso(Lasso):
+    """Version of sklearn Lasso that accepts weights.
+
+    Parameters
+    ----------
+    alpha : float, optional
+        Constant that multiplies the L1 term. Defaults to 1.0.
+        ``alpha = 0`` is equivalent to an ordinary least square, solved
+        by the :class:`LinearRegression` object. For numerical
+        reasons, using ``alpha = 0`` with the ``Lasso`` object is not advised.
+        Given this, you should use the :class:`LinearRegression` object.
+
+    fit_intercept : boolean, optional, default True
+        Whether to calculate the intercept for this model. If set
+        to False, no intercept will be used in calculations
+        (e.g. data is expected to be already centered).
+
+    precompute : True | False | array-like, default=False
+        Whether to use a precomputed Gram matrix to speed up
+        calculations. If set to ``'auto'`` let us decide. The Gram
+        matrix can also be passed as argument. For sparse input
+        this option is always ``True`` to preserve sparsity.
+
+    copy_X : boolean, optional, default True
+        If ``True``, X will be copied; else, it may be overwritten.
+
+    max_iter : int, optional
+        The maximum number of iterations
+
+    tol : float, optional
+        The tolerance for the optimization: if the updates are
+        smaller than ``tol``, the optimization code checks the
+        dual gap for optimality and continues until it is smaller
+        than ``tol``.
+
+    warm_start : bool, optional
+        When set to True, reuse the solution of the previous call to fit as
+        initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
+
+    positive : bool, optional
+        When set to ``True``, forces the coefficients to be positive.
+
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
+        The seed of the pseudo random number generator that selects a random
+        feature to update.  If int, random_state is the seed used by the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
+        number generator; If None, the random number generator is the
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection == 'random'``.
+
+    selection : str, default 'cyclic'
+        If set to 'random', a random coefficient is updated every iteration
+        rather than looping over features sequentially by default. This
+        (setting to 'random') often leads to significantly faster convergence
+        especially when tol is higher than 1e-4.
+
+    Attributes
+    ----------
+    coef_ : array, shape (n_features,) | (n_targets, n_features)
+        parameter vector (w in the cost function formula)
+
+    sparse_coef_ : scipy.sparse matrix, shape (n_features, 1) | (n_targets, n_features)
+        ``sparse_coef_`` is a readonly property derived from ``coef_``
+
+    intercept_ : float | array, shape (n_targets,)
+        independent term in decision function.
+
+    n_iter_ : int | array-like, shape (n_targets,)
+        number of iterations run by the coordinate descent solver to reach
+        the specified tolerance.
+    """
+
+    def __init__(self, alpha=1.0, fit_intercept=True,
+                 precompute=False, copy_X=True, max_iter=1000,
+                 tol=1e-4, warm_start=False, positive=False,
+                 random_state=None, selection='cyclic'):
+        super(WeightedLasso, self).__init__(
+            alpha=alpha, fit_intercept=fit_intercept,
+            normalize=False, precompute=precompute, copy_X=copy_X,
+            max_iter=max_iter, tol=tol, warm_start=warm_start,
+            positive=positive, random_state=random_state,
+            selection=selection)
+
+    def fit(self, X, y, sample_weight=None, check_input=True):
+        """Fit model with coordinate descent.
+
+        Parameters
+        ----------
+        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+            Data
+
+        y : ndarray, shape (n_samples,) or (n_samples, n_targets)
+            Target. Will be cast to X's dtype if necessary
+
+        sample_weight : numpy array of shape [n_samples]
+                        Individual weights for each sample.
+                        The weights will be normalized internally.
+
+        check_input : boolean, (default=True)
+            Allow to bypass several input checking.
+            Don't use this parameter unless you know what you do.
+        """
+        _fit_weighted_linear_model(self, WeightedLasso, X, y, sample_weight, check_input)
+        return self
+
+
+class WeightedMultiTaskLasso(MultiTaskLasso):
+    """Version of sklearn MultiTaskLasso that accepts weights.
+
+    Parameters
+    ----------
+    alpha : float, optional
+        Constant that multiplies the L1 term. Defaults to 1.0.
+        ``alpha = 0`` is equivalent to an ordinary least square, solved
+        by the :class:`LinearRegression` object. For numerical
+        reasons, using ``alpha = 0`` with the ``Lasso`` object is not advised.
+        Given this, you should use the :class:`LinearRegression` object.
+
+    fit_intercept : boolean, optional, default True
+        Whether to calculate the intercept for this model. If set
+        to False, no intercept will be used in calculations
+        (e.g. data is expected to be already centered).
+
+    copy_X : boolean, optional, default True
+        If ``True``, X will be copied; else, it may be overwritten.
+
+    max_iter : int, optional
+        The maximum number of iterations
+
+    tol : float, optional
+        The tolerance for the optimization: if the updates are
+        smaller than ``tol``, the optimization code checks the
+        dual gap for optimality and continues until it is smaller
+        than ``tol``.
+
+    warm_start : bool, optional
+        When set to True, reuse the solution of the previous call to fit as
+        initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
+
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
+        The seed of the pseudo random number generator that selects a random
+        feature to update.  If int, random_state is the seed used by the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
+        number generator; If None, the random number generator is the
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection == 'random'``.
+
+    selection : str, default 'cyclic'
+        If set to 'random', a random coefficient is updated every iteration
+        rather than looping over features sequentially by default. This
+        (setting to 'random') often leads to significantly faster convergence
+        especially when tol is higher than 1e-4.
+
+    Attributes
+    ----------
+    coef_ : array, shape (n_features,) | (n_targets, n_features)
+        parameter vector (w in the cost function formula)
+
+    intercept_ : float | array, shape (n_targets,)
+        independent term in decision function.
+
+    n_iter_ : int | array-like, shape (n_targets,)
+        number of iterations run by the coordinate descent solver to reach
+        the specified tolerance.
+    """
+
+    def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
+                 copy_X=True, max_iter=1000, tol=1e-4, warm_start=False,
+                 random_state=None, selection='cyclic'):
+        super(WeightedMultiTaskLasso, self).__init__(
+            alpha=alpha, fit_intercept=fit_intercept, normalize=False,
+            copy_X=copy_X, max_iter=max_iter, tol=tol, warm_start=warm_start,
+            random_state=random_state, selection=selection)
+
+    def fit(self, X, y, sample_weight=None):
+        """Fit model with coordinate descent.
+
+        Parameters
+        ----------
+        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+            Data
+
+        y : ndarray, shape (n_samples,) or (n_samples, n_targets)
+            Target. Will be cast to X's dtype if necessary
+
+        sample_weight : numpy array of shape [n_samples]
+                        Individual weights for each sample.
+                        The weights will be normalized internally.
+        """
+        _fit_weighted_linear_model(self, WeightedMultiTaskLasso, X, y, sample_weight)
+        return self
+
+
+class WeightedKFold:
+    """K-Folds cross-validator for weighted data.
+
+    Provides train/test indices to split data in train/test sets.
+    Split dataset into k folds of roughly equal size and equal total weight.
+
+    The default is to try sklearn.model_selection.KFold a number of trials to find
+    a weight-balanced k-way split. If it cannot find such a split, it will fall back
+    onto a more rigorous weight stratification algorithm.
+
+    Parameters
+    ----------
+    n_splits : int, default=3
+        Number of folds. Must be at least 2.
+
+    n_trials : int, default=10
+        Number of times to try sklearn.model_selection.KFold before falling back to another
+        weight stratification algorithm.
+
+    shuffle : boolean, optional
+        Whether to shuffle the data before splitting into batches.
+
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default=None
+        If int, random_state is the seed used by the random number generator;
+        If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
+        If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
+        by :mod:`np.random<numpy.random>`. Used when ``shuffle`` == True.
+    """
+
+    def __init__(self, n_splits=3, n_trials=10, shuffle=False, random_state=None):
+        self.n_splits = n_splits
+        self.shuffle = shuffle
+        self.n_trials = n_trials
+        self.random_state = random_state
+        return
+
+    def split(self, X, y, sample_weight=None):
+        """Generate indices to split data into training and test set.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            Training data, where n_samples is the number of samples
+            and n_features is the number of features.
+
+        y : array-like, shape (n_samples,)
+            The target variable for supervised learning problems.
+
+        sample_weight : array-like, shape (n_samples,)
+            Weights associated with the training data.
+        """
+        return _split_weighted_sample(self, X, y, sample_weight, is_stratified=False)
+
+    def _get_folds_from_splits(self, splits, sample_size):
+        folds = []
+        sample_indices = np.arange(sample_size)
+        for it in range(self.n_splits):
+            folds.append([np.setdiff1d(sample_indices, splits[it], assume_unique=True), splits[it]])
+        return folds
+
+    def _get_splits_from_weight_stratification(self, sample_weight):
+        # Weight stratification algorithm
+        # Sort weights for weight strata search
+        sorted_inds = np.argsort(sample_weight)
+        sorted_weights = sample_weight[sorted_inds]
+        max_split_size = sorted_weights.shape[0] // self.n_splits
+        max_divisible_length = max_split_size * self.n_splits
+        sorted_inds_subset = np.reshape(sorted_inds[:max_divisible_length], (max_split_size, self.n_splits))
+        shuffled_sorted_inds_subset = np.apply_along_axis(np.random.permutation, axis=1, arr=sorted_inds_subset)
+        splits = [list(shuffled_sorted_inds_subset[:, i]) for i in range(self.n_splits)]
+        if max_divisible_length != sorted_weights.shape[0]:
+            # There are some leftover indices that have yet to be assigned
+            subsample = sorted_inds[max_divisible_length:]
+            if self.shuffle:
+                np.random.shuffle(subsample)
+            new_splits = np.array_split(subsample, self.n_splits)
+            np.random.shuffle(new_splits)
+            # Append stratum splits to overall splits
+            splits = [split + list(new_split) for split, new_split in zip(splits, new_splits)]
+        return splits
+
+
+class WeightedStratifiedKFold(WeightedKFold):
+    """Stratified K-Folds cross-validator for weighted data.
+
+    Provides train/test indices to split data in train/test sets.
+    Split dataset into k folds of roughly equal size and equal total weight.
+
+    The default is to try sklearn.model_selection.StratifiedKFold a number of trials to find
+    a weight-balanced k-way split. If it cannot find such a split, it will fall back
+    onto a more rigorous weight stratification algorithm.
+
+    Parameters
+    ----------
+    n_splits : int, default=3
+        Number of folds. Must be at least 2.
+
+    n_trials : int, default=10
+        Number of times to try sklearn.model_selection.StratifiedKFold before falling back to another
+        weight stratification algorithm.
+
+    shuffle : boolean, optional
+        Whether to shuffle the data before splitting into batches.
+
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default=None
+        If int, random_state is the seed used by the random number generator;
+        If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random number generator;
+        If None, the random number generator is the :class:`~numpy.random.mtrand.RandomState` instance used
+        by :mod:`np.random<numpy.random>`. Used when ``shuffle`` == True.
+    """
+
+    def split(self, X, y, sample_weight=None):
+        """Generate indices to split data into training and test set.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            Training data, where n_samples is the number of samples
+            and n_features is the number of features.
+
+        y : array-like, shape (n_samples,)
+            The target variable for supervised learning problems.
+
+        sample_weight : array-like, shape (n_samples,)
+            Weights associated with the training data.
+        """
+        return _split_weighted_sample(self, X, y, sample_weight, is_stratified=True)
+
+
+class WeightedLassoCV(LassoCV):
+    """Version of sklearn LassoCV that accepts weights.
+
+    Parameters
+    ----------
+    eps : float, optional
+        Length of the path. ``eps=1e-3`` means that
+        ``alpha_min / alpha_max = 1e-3``.
+
+    n_alphas : int, optional
+        Number of alphas along the regularization path
+
+    alphas : numpy array, optional
+        List of alphas where to compute the models.
+        If ``None`` alphas are set automatically
+
+    fit_intercept : boolean, default True
+        whether to calculate the intercept for this model. If set
+        to false, no intercept will be used in calculations
+        (e.g. data is expected to be already centered).
+
+    precompute : True | False | 'auto' | array-like
+        Whether to use a precomputed Gram matrix to speed up
+        calculations. If set to ``'auto'`` let us decide. The Gram
+        matrix can also be passed as argument.
+
+    max_iter : int, optional
+        The maximum number of iterations
+
+    tol : float, optional
+        The tolerance for the optimization: if the updates are
+        smaller than ``tol``, the optimization code checks the
+        dual gap for optimality and continues until it is smaller
+        than ``tol``.
+
+    copy_X : boolean, optional, default True
+        If ``True``, X will be copied; else, it may be overwritten.
+
+    cv : int, cross-validation generator or an iterable, optional
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+        - None, to use the default 3-fold weighted cross-validation,
+        - integer, to specify the number of folds.
+        - :term:`CV splitter`,
+        - An iterable yielding (train, test) splits as arrays of indices.
+        For integer/None inputs, :class:`WeightedKFold` is used.
+
+    verbose : bool or integer
+        Amount of verbosity.
+
+    n_jobs : int or None, optional (default=None)
+        Number of CPUs to use during the cross validation.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+
+    positive : bool, optional
+        If positive, restrict regression coefficients to be positive
+
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
+        The seed of the pseudo random number generator that selects a random
+        feature to update.  If int, random_state is the seed used by the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
+        number generator; If None, the random number generator is the
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection == 'random'``.
+
+    selection : str, default 'cyclic'
+        If set to 'random', a random coefficient is updated every iteration
+        rather than looping over features sequentially by default. This
+        (setting to 'random') often leads to significantly faster convergence
+        especially when tol is higher than 1e-4.
+    """
+
+    def __init__(self, eps=1e-3, n_alphas=100, alphas=None, fit_intercept=True,
+                 precompute='auto', max_iter=1000, tol=1e-4, normalize=False,
+                 copy_X=True, cv='warn', verbose=False, n_jobs=None,
+                 positive=False, random_state=None, selection='cyclic'):
+
+        super().__init__(
+            eps=eps, n_alphas=n_alphas, alphas=alphas,
+            fit_intercept=fit_intercept, normalize=False,
+            precompute=precompute, max_iter=max_iter, tol=tol, copy_X=copy_X,
+            cv=cv, verbose=verbose, n_jobs=n_jobs, positive=positive,
+            random_state=random_state, selection=selection)
+
+    def fit(self, X, y, sample_weight=None):
+        """Fit model with coordinate descent.
+
+        Parameters
+        ----------
+        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+            Data
+
+        y : ndarray, shape (n_samples,) or (n_samples, n_targets)
+            Target. Will be cast to X's dtype if necessary
+
+        sample_weight : numpy array of shape [n_samples]
+                        Individual weights for each sample.
+                        The weights will be normalized internally.
+        """
+        # Make weighted splitter
+        cv_temp = self.cv
+        self.cv = _weighted_check_cv(self.cv).split(X, y, sample_weight=sample_weight)
+        # Fit weighted model
+        _fit_weighted_linear_model(self, WeightedLassoCV, X, y, sample_weight)
+        self.cv = cv_temp
+        return self
+
+
+class WeightedMultiTaskLassoCV(MultiTaskLassoCV):
+    """Version of sklearn MultiTaskLassoCV that accepts weights.
+
+    Parameters
+    ----------
+    eps : float, optional
+        Length of the path. ``eps=1e-3`` means that
+        ``alpha_min / alpha_max = 1e-3``.
+
+    n_alphas : int, optional
+        Number of alphas along the regularization path
+
+    alphas : array-like, optional
+        List of alphas where to compute the models.
+        If not provided, set automatically.
+
+    fit_intercept : boolean
+        whether to calculate the intercept for this model. If set
+        to false, no intercept will be used in calculations
+        (e.g. data is expected to be already centered).
+
+    max_iter : int, optional
+        The maximum number of iterations.
+
+    tol : float, optional
+        The tolerance for the optimization: if the updates are
+        smaller than ``tol``, the optimization code checks the
+        dual gap for optimality and continues until it is smaller
+        than ``tol``.
+
+    copy_X : boolean, optional, default True
+        If ``True``, X will be copied; else, it may be overwritten.
+
+    cv : int, cross-validation generator or an iterable, optional
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+        - None, to use the default 3-fold weighted cross-validation,
+        - integer, to specify the number of folds.
+        - :term:`CV splitter`,
+        - An iterable yielding (train, test) splits as arrays of indices.
+        For integer/None inputs, :class:`WeightedKFold` is used.
+
+    verbose : bool or integer
+        Amount of verbosity.
+
+    n_jobs : int or None, optional (default=None)
+        Number of CPUs to use during the cross validation. Note that this is
+        used only if multiple values for l1_ratio are given.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+
+    random_state : int, :class:`~numpy.random.mtrand.RandomState` instance or None, optional, default None
+        The seed of the pseudo random number generator that selects a random
+        feature to update.  If int, random_state is the seed used by the random
+        number generator; If :class:`~numpy.random.mtrand.RandomState` instance, random_state is the random
+        number generator; If None, the random number generator is the
+        :class:`~numpy.random.mtrand.RandomState` instance used by :mod:`np.random<numpy.random>`. Used when
+        ``selection == 'random'``.
+
+    selection : str, default 'cyclic'
+        If set to 'random', a random coefficient is updated every iteration
+        rather than looping over features sequentially by default. This
+        (setting to 'random') often leads to significantly faster convergence
+        especially when tol is higher than 1e-4.
+    """
+
+    def __init__(self, eps=1e-3, n_alphas=100, alphas=None, fit_intercept=True,
+                 normalize=False, max_iter=1000, tol=1e-4,
+                 copy_X=True, cv='warn', verbose=False, n_jobs=None,
+                 random_state=None, selection='cyclic'):
+
+        super().__init__(
+            eps=eps, n_alphas=n_alphas, alphas=alphas,
+            fit_intercept=fit_intercept, normalize=False,
+            max_iter=max_iter, tol=tol, copy_X=copy_X,
+            cv=cv, verbose=verbose, n_jobs=n_jobs,
+            random_state=random_state, selection=selection)
+
+    def fit(self, X, y, sample_weight=None):
+        """Fit model with coordinate descent.
+
+        Parameters
+        ----------
+        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+            Data
+
+        y : ndarray, shape (n_samples,) or (n_samples, n_targets)
+            Target. Will be cast to X's dtype if necessary
+
+        sample_weight : numpy array of shape [n_samples]
+                        Individual weights for each sample.
+                        The weights will be normalized internally.
+        """
+        # Make weighted splitter
+        cv_temp = self.cv
+        self.cv = _weighted_check_cv(self.cv).split(X, y, sample_weight=sample_weight)
+        # Fit weighted model
+        _fit_weighted_linear_model(self, WeightedMultiTaskLassoCV, X, y, sample_weight)
+        self.cv = cv_temp
+        return self
+
+
+class MultiModelWrapper:
+    """Helper class for assiging weights to models without this option.
 
     Parameters
     ----------
@@ -868,7 +1545,8 @@ class StatsModelsLinearRegression(BaseEstimator):
         return X, y, sample_weight, sample_var
 
     def fit(self, X, y, sample_weight=None, sample_var=None):
-        """Fits the model.
+        """
+        Fits the model.
 
         Parameters
         ----------
@@ -887,7 +1565,6 @@ class StatsModelsLinearRegression(BaseEstimator):
         -------
         self : StatsModelsLinearRegression
         """
-
         # TODO: Add other types of covariance estimation (e.g. Newey-West (HAC), HC2, HC3)
         X, y, sample_weight, sample_var = self._check_input(X, y, sample_weight, sample_var)
 
@@ -1006,8 +1683,7 @@ class StatsModelsLinearRegression(BaseEstimator):
     @property
     def _param_var(self):
         """
-        The covariance matrix of all the parameters in the regression (including the intercept
-        as the first parameter).
+        The covariance matrix of all the parameters in the regression (including the intercept as the first parameter).
 
         Returns
         -------


### PR DESCRIPTION
* Clean up cross references in docs (both between internal classes, as well as to external classes like numpy's `RandomState`)
* Remove explicit `object` base class in the few places we had it, since it's completely unnecessary in python 3