### PR TITLE
Switch to macOS 10.13 to mitigate CI delays

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,8 @@ variables:
 jobs:
 - job: 'EvalChanges'
   displayName: 'Analyze changed files to determine which job to run'
+  pool:
+    vmImage: 'macOS-10.13'
   steps:
   # We want to enforce the following rules for PRs:
   # * if all modifications are to README.md
@@ -55,6 +57,8 @@ jobs:
   condition: eq(dependencies.EvalChanges.outputs['output.buildDocs'], 'True')
   variables:
     python.version: '3.6'
+  pool:
+    vmImage: 'macOS-10.13'
   steps:
   - template: azure-pipelines-steps.yml
     parameters:
@@ -67,6 +71,8 @@ jobs:
   condition: eq(dependencies.EvalChanges.outputs['output.buildNbs'], 'True')
   variables:
     python.version: '3.6'
+  pool:
+    vmImage: 'macOS-10.13'
   steps:
   - template: azure-pipelines-steps.yml
     parameters:
@@ -93,7 +99,7 @@ jobs:
         imageName: 'ubuntu-16.04'
         python.version: '3.5'
       macOS, Python 3.5:
-        imageName: 'macOS-10.14'
+        imageName: 'macOS-10.13'
         python.version: '3.5'
       Windows, Python 3.5:
         imageName: 'vs2017-win2016'
@@ -102,7 +108,7 @@ jobs:
         imageName: 'ubuntu-16.04'
         python.version: '3.6'
       macOS, Python 3.6:
-        imageName: 'macOS-10.14'
+        imageName: 'macOS-10.13'
         python.version: '3.6'
       Windows, Python 3.6:
         imageName: 'vs2017-win2016'
@@ -111,7 +117,7 @@ jobs:
         imageName: 'ubuntu-16.04'
         python.version: '3.7'
       macOS, Python 3.7:
-        imageName: 'macOS-10.14'
+        imageName: 'macOS-10.13'
         python.version: '3.7'
       Windows, Python 3.7:
         imageName: 'vs2017-win2016'


### PR DESCRIPTION
We've been experiencing long delays with our CI builds, somehow involving the jobs that run on macOS; this PR is a temporary measure to see if we can mitigate the issue by using a different OS version.