### PR TITLE
Fix some documentation problems

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,9 @@ jobs:
         - script: 'sudo apt-get -yq install graphviz'
           displayName: 'Install graphviz'
 
+        - script: 'pip install sklearn-contrib-lightning'
+          displayName: 'Install lightning'
+
         - script: 'python setup.py build_sphinx -W'
           displayName: 'Build documentation'
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -17,6 +17,8 @@ Public Module Reference
     econml.drlearner
     econml.two_stage_least_squares
     econml.utilities
+    econml.sklearn_extensions.linear_model
+    econml.sklearn_extensions.model_selection    
 
 Private Module Reference
 ========================

--- a/doc/spec/estimation/dml.rst
+++ b/doc/spec/estimation/dml.rst
@@ -29,9 +29,9 @@ provide *valid inference* (confidence interval construction) for measuring the u
 What are the relevant estimator classes?
 ========================================
 
-This section describes the methodology implemented in the classes, :py:class:`~econml._rlearner._RLearner`,
-:py:class:`~econml.dml.DMLCateEstimator`, :py:class:`~econml.dml.LinearDMLCateEstimator`,
-:py:class:`~econml.dml.SparseLinearDMLCateEstimator`, :py:class:`~econml.dml.KernelDMLCateEstimator`. Click on each of these links for a detailed module documentation and input parameters of each class.
+This section describes the methodology implemented in the classes, :class:`._RLearner`,
+:class:`.DMLCateEstimator`, :class:`.LinearDMLCateEstimator`,
+:class:`.SparseLinearDMLCateEstimator`, :class:`.KernelDMLCateEstimator`. Click on each of these links for a detailed module documentation and input parameters of each class.
 
 
 When should you use it?
@@ -116,7 +116,7 @@ linear function,
 The main advantage of DML is that if one makes parametric assumptions on :math:`\theta(X)`, then one achieves fast estimation rates and 
 asymptotic normality on the second stage estimate :math:`\hat{\theta}`, even if the first stage estimates on :math:`q(X, W)` 
 and :math:`f(X, W)` are only :math:`n^{1/4}` consistent, in terms of RMSE. For this theorem to hold, the nuisance
-estimates need to be fitted in a cross-fitting manner (see :py:class:`~econml._ortho_learner._OrthoLearner`).
+estimates need to be fitted in a cross-fitting manner (see :class:`._OrthoLearner`).
 The latter robustness property follows from the fact that the moment equations that correspond to the final 
 least squares estimation (i.e. the gradient of the squared loss), satisfy a Neyman orthogonality condition with respect to the
 nuisance parameters :math:`q, f`. For a more detailed exposition of how Neyman orthogonality 
@@ -136,8 +136,8 @@ structure of the implemented CATE estimators is as follows.
 
 Below we give a brief description of each of these classes:
 
-    * *DMLCateEstimator.* The class :py:class:`~econml.dml.DMLCateEstimator` assumes that the effect model for each outcome :math:`i` and treatment :math:`j` is linear, i.e. takes the form :math:`\theta_{ij}(X)=\langle \theta_{ij}, \phi(X)\rangle`, and allows for any arbitrary scikit-learn linear estimator to be defined as the final stage (e.g.    
-      :py:class:`~sklearn.linear_model.ElasticNet`, :py:class:`~sklearn.linear_model.Lasso`, :py:class:`~sklearn.linear_model.LinearRegression` and their multi-task variations in the case where we have mulitple outcomes, i.e. :math:`Y` is a vector). The final linear model will be fitted on features that are derived by the Kronecker-product
+    * *DMLCateEstimator.* The class :class:`.DMLCateEstimator` assumes that the effect model for each outcome :math:`i` and treatment :math:`j` is linear, i.e. takes the form :math:`\theta_{ij}(X)=\langle \theta_{ij}, \phi(X)\rangle`, and allows for any arbitrary scikit-learn linear estimator to be defined as the final stage (e.g.    
+      :class:`~sklearn.linear_model.ElasticNet`, :class:`~sklearn.linear_model.Lasso`, :class:`~sklearn.linear_model.LinearRegression` and their multi-task variations in the case where we have mulitple outcomes, i.e. :math:`Y` is a vector). The final linear model will be fitted on features that are derived by the Kronecker-product
       of the vectors :math:`T` and :math:`\phi(X)`, i.e. :math:`\tilde{T}\otimes \phi(X) = \mathtt{vec}(\tilde{T}\cdot \phi(X)^T)`. This regression will estimate the coefficients :math:`\theta_{ijk}` 
       for each outcome :math:`i`, treatment :math:`j` and feature :math:`k`. The final model is minimizing a regularized empirical square loss of the form:
       
@@ -170,10 +170,10 @@ Below we give a brief description of each of these classes:
       constraints on the matrix :math:`\Theta`.
       This essentially implements the techniques analyzed in [Chernozhukov2016]_, [Nie2017]_, [Chernozhukov2017]_, [Chernozhukov2018]_
         
-        - *LinearDMLCateEstimator.* The child class  :py:class:`~econml.dml.LinearDMLCateEstimator`, uses an unregularized final linear model and  
+        - *LinearDMLCateEstimator.* The child class  :class:`.LinearDMLCateEstimator`, uses an unregularized final linear model and  
           essentially works only when the feature vector :math:`\phi(X)` is low dimensional. Given that it is an unregularized
           low dimensional final model, this class also offers confidence intervals via asymptotic normality 
-          arguments. This is achieved by essentially using the :py:class:`~econml.utilities.StatsModelsLinearRegression`
+          arguments. This is achieved by essentially using the :class:`.StatsModelsLinearRegression`
           (which is an extension of the scikit-learn LinearRegression estimator, that also supports inference
           functionalities) as a final model. The theoretical foundations of this class essentially follow the arguments in [Chernozhukov2016]_.
           For instance, to get confidence intervals on the effect of going
@@ -186,8 +186,8 @@ Below we give a brief description of each of these classes:
 
           One could also construct bootstrap based confidence intervals by setting `inference='bootstrap'`.
 
-        - *SparseLinearDMLCateEstimator.* The child class :py:class:`~econml.dml.SparseLinearDMLCateEstimator`, uses an :math:`\ell_1`-regularized final    
-          model. In particular, it uses an implementation of the DebiasedLasso algorithm [Buhlmann2011]_ (see :py:class:`~econml.sklearn_extensions.linear_model.DebiasedLasso`). Using the asymptotic normality properties
+        - *SparseLinearDMLCateEstimator.* The child class :class:`.SparseLinearDMLCateEstimator`, uses an :math:`\ell_1`-regularized final    
+          model. In particular, it uses an implementation of the DebiasedLasso algorithm [Buhlmann2011]_ (see :class:`.DebiasedLasso`). Using the asymptotic normality properties
           of the debiased lasso, this class also offers asymptotically normal based confidence intervals.
           The theoretical foundations of this class essentially follow the arguments in [Chernozhukov2017]_, [Chernozhukov2018]_.
           For instance, to get confidence intervals on the effect of going
@@ -198,21 +198,21 @@ Below we give a brief description of each of these classes:
             point = est.effect(X, T0=T0, T1=T1)
             lb, ub = est.effect_interval(X, T0=T0, T1=T1, alpha=0.05)
 
-        - *KernelDMLCateEstimator.* The child class :py:class:`~econml.dml.KernelDMLCateEstimator` performs a variant of the RKHS approach proposed in 
+        - *KernelDMLCateEstimator.* The child class :class:`.KernelDMLCateEstimator` performs a variant of the RKHS approach proposed in 
           [Nie2017]_. It approximates any function in the RKHS by creating random Fourier features. Then runs a ElasticNet
           regularized final model. Thus it approximately implements the results of [Nie2017], via the random fourier feature
           approximate representation of functions in the RKHS. Moreover, given that we use Random Fourier Features this class
           asssumes an RBF kernel.
     
-    - *_RLearner.* The internal private class :py:class:`~econml._rlearner._RLearner` is a parent of the :py:class:`~econml.dml.DMLCateEstimator`
+    - *_RLearner.* The internal private class :class:`._RLearner` is a parent of the :class:`.DMLCateEstimator`
       and allows the user to specify any way of fitting a final model that takes as input the residual :math:`\tilde{T}`,
       the features :math:`X` and predicts the residual :math:`\tilde{Y}`. Moreover, the nuisance models take as input
       :math:`X` and :math:`W` and predict :math:`T` and :math:`Y` respectively. Since these models take non-standard
       input variables, one cannot use out-of-the-box scikit-learn estimators as inputs to this class. Hence, it is
       slightly more cumbersome to use, which is the reason why we designated it as private. However, if one wants to
       fit for instance a neural net model for :math:`\theta(X)`, then this class can be used (see the implementation
-      of the :py:class:`~econml.dml.DMLCateEstimator` of how to wrap sklearn estimators and pass them as inputs to the
-      :py:class:`~econml._rlearner._RLearner`. This private class essentially follows the general arguments and
+      of the :class:`.DMLCateEstimator` of how to wrap sklearn estimators and pass them as inputs to the
+      :class:`._RLearner`. This private class essentially follows the general arguments and
       terminology of the RLearner presented in [Nie2017]_, and allows for the full flexibility of the final model
       estimation that is presented in [Foster2019]_.
 
@@ -223,9 +223,9 @@ Usage FAQs
 
 - **What if I want confidence intervals?**
 
-    For valid confidence intervals use the :py:class:`~econml.dml.LinearDMLCateEstimator` if the number of features :math:`X`,
+    For valid confidence intervals use the :class:`.LinearDMLCateEstimator` if the number of features :math:`X`,
     that you want to use for heterogeneity are small compared to the number of samples that you have. If the number of
-    features is comparable to the number of samples, then use :py:class:`~econml.dml.SparseLinearDMLCateEstimator`.
+    features is comparable to the number of samples, then use :class:`.SparseLinearDMLCateEstimator`.
     e.g.::
 
         from econml.dml import LinearDMLCateEstimator
@@ -241,7 +241,7 @@ Usage FAQs
     potential approach one could take is simply run a big linear regression, regressing :math:`Y` on
     :math:`T, X, W` and then looking at the coefficient associated with the :math:`T` variable and
     the corresponding confidence interval (e.g. using statistical packages like
-    :py:class:`~statsmodels.api.OLS`). However, this will not work if:
+    :class:`~statsmodels.api.OLS`). However, this will not work if:
 
         1) The number of control variables :math:`X, W` that you have is large and comparable
         to the number of samples. This could for instance arise if one wants to control for
@@ -267,7 +267,7 @@ Usage FAQs
 
         1) If effect heterogeneity does not have a linear form, then this approach is not valid.
         One might want to then create more complex featurization, in which case the problem could
-        become too high-dimensional for OLS. Our :py:class:`~econml.dml.SparseLinearDMLCateEstimator`
+        become too high-dimensional for OLS. Our :class:`.SparseLinearDMLCateEstimator`
         can handle such settings via the use of the debiased Lasso. Also see the :ref:`Orthogonal Random Forest User Guide <orthoforestuserguide>` or, if your treatment is categorical, then also check the :ref:`Meta Learners User Guide <metalearnersuserguide>`, if you want even more flexible CATE models.
 
         2) If the number of features :math:`X` is comparable to the number of samples, then even
@@ -277,7 +277,7 @@ Usage FAQs
 - **What if I have no idea how heterogeneity looks like?**
 
     Either use a flexible featurizer, e.g. a polynomial featurizer with many degrees and use
-    the :py:class:`~econml.dml.SparseLinearDMLCateEstimator`::
+    the :class:`.SparseLinearDMLCateEstimator`::
 
         from econml.dml import SparseLinearDMLCateEstimator
         from sklearn.preprocessing import PolynomialFeatures
@@ -291,7 +291,7 @@ Usage FAQs
 
 - **What if I have too many features that can create heterogeneity?**
 
-    Use the :py:class:`~econml.dml.SparseLinearDMLCateEstimator` (see above).
+    Use the :class:`.SparseLinearDMLCateEstimator` (see above).
 
 - **What if I have too many features I want to control for?**
 
@@ -318,8 +318,8 @@ Usage FAQs
 - **How do I select the hyperparameters of the first stage models?**
 
     You can use cross-validated models that automatically choose the hyperparameters, e.g. the
-    :py:class:`~sklearn.linear_model.LassoCV` instead of the :py:class:`~sklearn.linear_model.Lasso`. Similarly,
-    for forest based estimators you can wrap them with a grid search CV, :py:class:`~sklearn.model_selection.GridSearchCV`, e.g.::
+    :class:`~sklearn.linear_model.LassoCV` instead of the :class:`~sklearn.linear_model.Lasso`. Similarly,
+    for forest based estimators you can wrap them with a grid search CV, :class:`~sklearn.model_selection.GridSearchCV`, e.g.::
 
         from econml.dml import DMLCateEstimator
         from sklearn.model_selection import GridSearchCV
@@ -364,7 +364,7 @@ Usage FAQs
         point = est.const_marginal_effect(X)
         est.effect(X, T0=poly.transform(T0), T1=poly.transform(T1)) 
 
-    If your treatments are too many, then you can use the :py:class:`~econml.dml.SparseLinearDMLCateEstimator`. However,
+    If your treatments are too many, then you can use the :class:`.SparseLinearDMLCateEstimator`. However,
     this method will essentially impose a regularization that only a small subset of them has any effect.
 
 - **What if my treatments are continuous and don't have a linear effect on the outcome?**
@@ -418,7 +418,7 @@ Usage FAQs
 - **How should I set the parameter `n_splits`?**
 
     This parameter defines the number of data partitions to create in order to fit the first stages in a
-    crossfittin manner (see :py:class:`~econml._ortho_learner._OrthoLearner`). The default is 2, which
+    crossfittin manner (see :class:`._OrthoLearner`). The default is 2, which
     is the minimal. However, larger values like 5 or 6 can lead to greater statistical stability of the method,
     especially if the number of samples is small. So we advise that for small datasets, one should raise this
     value. This can increase the computational cost as more first stage models are being fitted.

--- a/doc/spec/estimation/forest.rst
+++ b/doc/spec/estimation/forest.rst
@@ -14,7 +14,7 @@ the heterogeneous treatment effect :math:`\theta(X)`, on a lower dimensional set
 Moreover, the estimates are asymptotically normal and hence have theoretical properties
 that render bootstrap based confidence intervals asymptotically valid. 
 
-In the case of continuous treatments (see :py:class:`~econml.ortho_forest.ContinuousTreatmentOrthoForest`) the method estimates :math:`\theta(x)` for some target :math:`x` by solving the following
+In the case of continuous treatments (see :class:`.ContinuousTreatmentOrthoForest`) the method estimates :math:`\theta(x)` for some target :math:`x` by solving the following
 system of equations:
 
 .. math::
@@ -55,7 +55,7 @@ the final stage estimation, in a cross-fitting manner).
 Algorithmically, the nuisance estimation part of the method is implemented in a
 flexible manner, not restricted to :math:`\ell_1` regularization, as follows: the user can define any class that
 supports fit and predict. The fit function needs to also support sample weights, passed as a third argument. 
-If it does not, then we provided a weighted model wrapper :py:class:`~econml.ortho_forest.WeightedModelWrapper` that
+If it does not, then we provided a weighted model wrapper :class:`.WeightedModelWrapper` that
 can wrap any class that supports fit and predict and enables sample weight functionality. This is done either
 by re-sampling the data based on the weights and then calling fit and predict, or, in the case of square losses of
 linear function classes, by re-scaling the features and labels appropriately based on the weights:
@@ -80,7 +80,7 @@ If not, then it re-samples the data based on the weights and calls the fit metho
 class on this re-sampled dataset. The latter has higher variance and should not be chosen if the
 first approach is applicable.
 
-In the case of discrete treatments (see :py:class:`~econml.ortho_forest.DiscreteTreatmentOrthoForest`) the
+In the case of discrete treatments (see :class:`.DiscreteTreatmentOrthoForest`) the
 method estimates :math:`\theta(x)` for some target :math:`x` by solving a slightly different
 set of equations (see [Oprescu2019]_ for a theoretical exposition of why a different set of
 estimating equations is used). In particular, suppose that the treatment :math:`T` takes
@@ -107,8 +107,8 @@ a multi-class classification model and should support :code:`predict_proba`.
 For more details on the input parameters of the orthogonal forest classes and how to customize
 the estimator checkout the two modules:
 
-- :py:class:`~econml.ortho_forest.DiscreteTreatmentOrthoForest`
-- :py:class:`~econml.ortho_forest.ContinuousTreatmentOrthoForest`
+- :class:`.DiscreteTreatmentOrthoForest`
+- :class:`.ContinuousTreatmentOrthoForest`
 
 For more examples check out our 
 `OrthoForest Jupyter notebook <https://github.com/Microsoft/EconML/blob/master/notebooks/Orthogonal%20Random%20Forest%20Examples.ipynb>`_ 
@@ -116,7 +116,7 @@ For more examples check out our
 Examples
 --------
 
-Here is a simple example of how to call :py:class:`~econml.ortho_forest.ContinuousTreatmentOrthoForest`
+Here is a simple example of how to call :class:`.ContinuousTreatmentOrthoForest`
 and what the returned values correspond to in a simple data generating process:
 
     .. testcode::
@@ -138,7 +138,7 @@ and what the returned values correspond to in a simple data generating process:
     [[1. ]
      [1.2]]
 
-Similarly, we can call :py:class:`~econml.ortho_forest.DiscreteTreatmentOrthoForest`:
+Similarly, we can call :class:`.DiscreteTreatmentOrthoForest`:
 
     >>> T = np.array([0, 1]*60)
     >>> W = np.array([0, 1, 1, 0]*30).reshape(-1, 1)
@@ -153,7 +153,7 @@ Similarly, we can call :py:class:`~econml.ortho_forest.DiscreteTreatmentOrthoFor
 
 Let's now look at a more involved example with a high-dimensional set of confounders :math:`W`
 and with more realistic noisy data. In this case we can just use the default parameters
-of the class, which specify the use of the :py:class:`~sklearn.linear_model.LassoCV` for 
+of the class, which specify the use of the :class:`~sklearn.linear_model.LassoCV` for 
 both the treatment and the outcome regressions, in the case of continuous treatments.
 
     >>> from econml.ortho_forest import ContinuousTreatmentOrthoForest

--- a/doc/spec/estimation/metalearners.rst
+++ b/doc/spec/estimation/metalearners.rst
@@ -25,7 +25,7 @@ The T-Learner models :math:`Y(0)`, :math:`Y(1)` separately. The estimated CATE i
 where :math:`\hat{\mu}_0 = M_0(Y^0\sim X^0),\; \hat{\mu}_1 = M_1(Y^1\sim X^1)` are the outcome models for the control and treatment group, respectively. Here, :math:`M_0`, :math:`M_1` can be any suitable machine learning algorithms that can learn the relationship between features and outcome.
 
 The EconML package provides the following implementation of the T-Learner:
-:py:class:`~econml.metalearners.TLearner`
+:class:`.TLearner`
 
 S-Learner
 -----------
@@ -40,7 +40,7 @@ The S-Learner models :math:`Y(0)` and :math:`Y(1)` through one model that receiv
 where :math:`\hat{\mu}=M(Y \sim (X, T))` is the outcome model for features :math:`X, T`. Here, :math:`M` is any suitable machine learning algorithm.
  
 The EconML package provides the following implementation of the S-Learner: 
-:py:class:`~econml.metalearners.SLearner`
+:class:`.SLearner`
 
 X-Learner
 -----------
@@ -60,7 +60,7 @@ The X-Learner models :math:`Y(1)` and :math:`Y(0)` separately in order to estima
 where :math:`g(x)` is an estimation of :math:`P[T=1| X]` and :math:`M_1, M_2, M_3, M_4` are suitable machine learning algorithms. 
 
 The EconML package provides the following implementation of the X-Learner: 
-:py:class:`~econml.metalearners.XLearner`
+:class:`.XLearner`
 
 
 Domain Adaptation Learner
@@ -84,7 +84,7 @@ where :math:`g(x)` is an estimation of :math:`P[T=1| X]`, :math:`M_1, M_2, M_3` 
 dataset concatenation. 
 
 The EconML package provides the following implementation of the Domain Adaptation Learner: 
-:py:class:`~econml.metalearners.DomainAdaptationLearner`
+:class:`.DomainAdaptationLearner`
 
 
 Doubly Robust Learner
@@ -101,7 +101,7 @@ it first constructs the proxies:
 and then runs a regression between :math:`Y_{i, 1}^{DR} - Y_{i, 0}^{DR}` and :math:`X`.
 
 The EconML package provides the following implementation of the Doubly Robust Learner: 
-:py:class:`~econml.drlearner.DRLearner`
+:class:`.DRLearner`
 
 
 .. todo::

--- a/doc/spec/inference.rst
+++ b/doc/spec/inference.rst
@@ -6,7 +6,7 @@ Generic Inference
 Bootstrap Subsampling
 ---------------------
 
-We provide a generic bootstrap sampling estimator :py:class:`~econml.bootstrap.BootstrapEstimator` that can wrap either sklearn 
+We provide a generic bootstrap sampling estimator :class:`.BootstrapEstimator` that can wrap either sklearn 
 or econml estimators.  This requires the wrapped object to provide a fit method, whose signature will be reused by the bootstrap 
 estimator (called on each of the cloned instances with a subsample of the data).
 

--- a/econml/_ortho_learner.py
+++ b/econml/_ortho_learner.py
@@ -273,9 +273,9 @@ class _OrthoLearner(TreatmentExpansionMixin, LinearCateEstimator):
     --------
 
     The example code below implements a very simple version of the double machine learning
-    method on top of the :py:class:`~econml._ortho_learner._OrthoLearner` class, for expository purposes.
+    method on top of the :class:`._OrthoLearner` class, for expository purposes.
     For a more elaborate implementation of a Double Machine Learning child class of the class
-    :py:class:`~econml._ortho_learner._OrthoLearner` check out :py:class:`~econml.dml.DMLCateEstimator`
+    :class:`._OrthoLearner` check out :class:`.DMLCateEstimator`
     and its child classes:
 
     .. testcode::

--- a/econml/_rlearner.py
+++ b/econml/_rlearner.py
@@ -47,11 +47,11 @@ from ._ortho_learner import _OrthoLearner
 class _RLearner(_OrthoLearner):
     """
     Base class for CATE learners that residualize treatment and outcome and run residual on residual regression.
-    The estimator is a special of an :class:`~econml._ortho_learner._OrthoLearner` estimator,
+    The estimator is a special of an :class:`._OrthoLearner` estimator,
     so it follows the two
     stage process, where a set of nuisance functions are estimated in the first stage in a crossfitting
     manner and a final stage estimates the CATE model. See the documentation of
-    :class:`~econml._ortho_learner._OrthoLearner` for a description of this two stage process.
+    :class:`._OrthoLearner` for a description of this two stage process.
 
     In this estimator, the CATE is estimated by using the following estimating equations:
 
@@ -125,9 +125,9 @@ class _RLearner(_OrthoLearner):
     Examples
     --------
     The example code below implements a very simple version of the double machine learning
-    method on top of the :py:class:`~econml._ortho_learner._RLearner` class, for expository purposes.
+    method on top of the :class:`._RLearner` class, for expository purposes.
     For a more elaborate implementation of a Double Machine Learning child class of the class
-    checkout :py:class:`~econml.dml.DMLCateEstimator` and its child classes:
+    checkout :class:`.DMLCateEstimator` and its child classes:
 
     .. testcode::
 
@@ -274,7 +274,7 @@ class _RLearner(_OrthoLearner):
 
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, inference=None):
         """
-        Estimate the counterfactual model from data, i.e. estimates function: math: `\\theta(\\cdot)`.
+        Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
 
         Parameters
         ----------

--- a/econml/cate_estimator.py
+++ b/econml/cate_estimator.py
@@ -479,7 +479,7 @@ class StatsModelsCateEstimatorMixin(LinearModelFinalCateEstimatorMixin):
     that inherits it.
 
     Such an estimator must implement a :attr:`model_final` attribute that points
-    to the fitted final :py:class:`~econml.utilities.StatsModelsLinearRegression` object that
+    to the fitted final :class:`.StatsModelsLinearRegression` object that
     represents the fitted CATE model.
     """
 
@@ -595,7 +595,7 @@ class StatsModelsCateEstimatorDiscreteMixin(LinearModelFinalCateEstimatorDiscret
     that inherits it.
 
     Such an estimator must implement a :attr:`model_final` attribute that points
-    to a :py:class:`~econml.utilities.StatsModelsLinearRegression` object that is cloned to fit
+    to a :class:`.StatsModelsLinearRegression` object that is cloned to fit
     each discrete treatment target CATE model and a :attr:`fitted_models_final` attribute
     that returns the list of fitted final models that represent the CATE for each categorical treatment.
     """

--- a/econml/dml.py
+++ b/econml/dml.py
@@ -58,11 +58,11 @@ from .sklearn_extensions.model_selection import WeightedStratifiedKFold
 class DMLCateEstimator(_RLearner):
     """
     The base class for parametric Double ML estimators. The estimator is a special
-    case of an :class:`~econml._rlearner._RLearner` estimator, which in turn is a special case
-    of an :class:`~econml._ortho_learner._OrthoLearner` estimator, so it follows the two
+    case of an :class:`._RLearner` estimator, which in turn is a special case
+    of an :class:`_OrthoLearner` estimator, so it follows the two
     stage process, where a set of nuisance functions are estimated in the first stage in a crossfitting
     manner and a final stage estimates the CATE model. See the documentation of
-    :class:`~econml._ortho_learner._OrthoLearner` for a description of this two stage process.
+    :class:`._OrthoLearner` for a description of this two stage process.
 
     In this estimator, the CATE is estimated by using the following estimating equations:
 
@@ -88,15 +88,15 @@ class DMLCateEstimator(_RLearner):
 
     For some given feature mapping :math:`\\phi(X)` (the user can provide this featurizer via the `featurizer`
     parameter at init time and could be any arbitrary class that adheres to the scikit-learn transformer
-    interface :py:class:`~sklearn.base.TransformerMixin`).
+    interface :class:`~sklearn.base.TransformerMixin`).
 
     The second nuisance function :math:`q` is a simple regression problem and the
-    :class:`~econml.dml.DMLCateEstimator`
+    :class:`.DMLCateEstimator`
     class takes as input the parameter `model_y`, which is an arbitrary scikit-learn regressor that
     is internally used to solve this regression problem.
 
     The problem of estimating the nuisance function :math:`f` is also a regression problem and
-    the :class:`~econml.dml.DMLCateEstimator`
+    the :class:`.DMLCateEstimator`
     class takes as input the parameter `model_t`, which is an arbitrary scikit-learn regressor that
     is internally used to solve this regression problem. If the init flag `discrete_treatment` is set
     to `True`, then the parameter `model_t` is treated as a scikit-learn classifier. The input categorical
@@ -107,7 +107,7 @@ class DMLCateEstimator(_RLearner):
     The final stage is (potentially multi-task) linear regression problem with outcomes the labels
     :math:`\\tilde{Y}` and regressors the composite features
     :math:`\\tilde{T}\\otimes \\phi(X) = \\mathtt{vec}(\\tilde{T}\\cdot \\phi(X)^T)`.
-    The :class:`~econml.dml.DMLCateEstimator` takes as input parameter
+    The :class:`.DMLCateEstimator` takes as input parameter
     ``model_final``, which is any linear scikit-learn regressor that is internally used to solve this
     (multi-task) linear regresion problem.
 
@@ -121,10 +121,10 @@ class DMLCateEstimator(_RLearner):
         The estimator for fitting the treatment to the features.
         If estimator, it must implement `fit` and `predict` methods.  Must be a linear model for correctness
         when linear_first_stages is ``True``;
-        If 'auto', :class:`LogisticRegressionCV() <sklearn.linear_model.LogisticRegressionCV>`
+        If 'auto', :class:`~sklearn.linear_model.LogisticRegressionCV`
         will be applied for discrete treatment,
-        and :class:`WeightedLassoCV() <econml.sklearn_extensions.linear_model.WeightedLassoCV>`/
-        :class:`WeightedMultitaskLassoCV() <econml.sklearn_extensions.linear_model.WeightedMultitaskLassoCV>`
+        and :class:`.WeightedLassoCV`/
+        :class:`.WeightedMultiTaskLassoCV`
         will be applied for continuous treatment.
 
     model_final: estimator
@@ -383,18 +383,15 @@ class LinearDMLCateEstimator(StatsModelsCateEstimatorMixin, DMLCateEstimator):
 
     Parameters
     ----------
-    model_y: estimator, optional (default is :class:`WeightedLassoCVWrapper()
-        <econml.sklearn_extensions.linear_model.WeightedLassoCVWrapper>`)
+    model_y: estimator, optional (default is :class:`.WeightedLassoCVWrapper`)
         The estimator for fitting the response to the features. Must implement
         `fit` and `predict` methods.
 
     model_t: estimator or 'auto', optional (default is 'auto')
         The estimator for fitting the treatment to the features.
         If estimator, it must implement `fit` and `predict` methods;
-        If 'auto', :class:`LogisticRegressionCV() <sklearn.linear_model.LogisticRegressionCV>`
-        will be applied for discrete treatment,
-        and :class:`WeightedLassoCV() <econml.sklearn_extensions.linear_model.WeightedLassoCV>`/
-        :class:`WeightedMultitaskLassoCV() <econml.sklearn_extensions.linear_model.WeightedMultitaskLassoCV>`
+        If 'auto', :class:`~sklearn.linear_model.LogisticRegressionCV` will be applied for discrete treatment,
+        and :class:`.WeightedLassoCV`/:class:`.WeightedMultiTaskLassoCV`
         will be applied for continuous treatment.
 
     featurizer : :term:`transformer`, optional, default None
@@ -495,7 +492,7 @@ class SparseLinearDMLCateEstimator(DebiasedLassoCateEstimatorMixin, DMLCateEstim
     and the coefficients of the linear CATE function are sparse.
 
     The last stage is an instance of the
-    :class:`MultiOutputDebiasedLasso <econml.sklearn_extensions.linear_model.MultiOutputDebiasedLasso>`
+    :class:`.MultiOutputDebiasedLasso`
 
     Parameters
     ----------
@@ -508,10 +505,10 @@ class SparseLinearDMLCateEstimator(DebiasedLassoCateEstimatorMixin, DMLCateEstim
         The estimator for fitting the treatment to the features.
         If estimator, it must implement `fit` and `predict` methods, and must be a
         linear model for correctness;
-        If 'auto', :class:`LogisticRegressionCV() <sklearn.linear_model.LogisticRegressionCV>`
+        If 'auto', :class:`~sklearn.linear_model.LogisticRegressionCV`
         will be applied for discrete treatment,
-        and :class:`WeightedLassoCV() <econml.sklearn_extensions.linear_model.WeightedLassoCV>`/
-        :class:`WeightedMultitaskLassoCV() <econml.sklearn_extensions.linear_model.WeightedMultitaskLassoCV>`
+        and :class:`.WeightedLassoCV`/
+        :class:`.WeightedMultiTaskLassoCV`
         will be applied for continuous treatment.
 
     alpha: string | float, optional. Default='auto'.
@@ -640,10 +637,10 @@ class KernelDMLCateEstimator(DMLCateEstimator):
     model_t: estimator or 'auto', optional (default is 'auto')
         The estimator for fitting the treatment to the features.
         If estimator, it must implement `fit` and `predict` methods;
-        If 'auto', :class:`LogisticRegressionCV() <sklearn.linear_model.LogisticRegressionCV>`
+        If 'auto', :class:`~sklearn.linear_model.LogisticRegressionCV`
         will be applied for discrete treatment,
-        and :class:`WeightedLassoCV() <econml.sklearn_extensions.linear_model.WeightedLassoCV>`/
-        :class:`WeightedMultitaskLassoCV() <econml.sklearn_extensions.linear_model.WeightedMultitaskLassoCV>`
+        and :class:`.WeightedLassoCV`/
+        :class:`.WeightedMultiTaskLassoCV`
         will be applied for continuous treatment.
 
     fit_cate_intercept : bool, optional, default True

--- a/econml/drlearner.py
+++ b/econml/drlearner.py
@@ -51,10 +51,10 @@ class DRLearner(_OrthoLearner):
     """
     CATE estimator that uses doubly-robust correction techniques to account for
     covariate shift (selection bias) between the treatment arms. The estimator is a special
-    case of an :class:`~econml._ortho_learner._OrthoLearner` estimator, so it follows the two
+    case of an :class:`._OrthoLearner` estimator, so it follows the two
     stage process, where a set of nuisance functions are estimated in the first stage in a crossfitting
     manner and a final stage estimates the CATE model. See the documentation of
-    :class:`~econml._ortho_learner._OrthoLearner` for a description of this two stage process.
+    :class:`._OrthoLearner` for a description of this two stage process.
 
     In this estimator, the CATE is estimated by using the following estimating equations. If we let:
 
@@ -72,16 +72,16 @@ class DRLearner(_OrthoLearner):
     treatment t, by running a regression, regressing :math:`Y_{i, t}^{DR} - Y_{i, 0}^{DR}` on :math:`X_i`.
 
     The problem of estimating the nuisance function :math:`p` is a simple multi-class classification
-    problem of predicting the label :math:`T` from :math:`X, W`. The :class:`~econml.drlearner.DRLearner`
+    problem of predicting the label :math:`T` from :math:`X, W`. The :class:`.DRLearner`
     class takes as input the parameter ``model_propensity``, which is an arbitrary scikit-learn
     classifier, that is internally used to solve this classification problem.
 
-    The second nuisance function :math:`h` is a simple regression problem and the :class:`~econml.drlearner.DRLearner`
+    The second nuisance function :math:`h` is a simple regression problem and the :class:`.DRLearner`
     class takes as input the parameter `model_regressor``, which is an arbitrary scikit-learn regressor that
     is internally used to solve this regression problem.
 
     The final stage is multi-task regression problem with outcomes the labels :math:`Y_{i, t}^{DR} - Y_{i, 0}^{DR}`
-    for each non-baseline treatment t. The :class:`~econml.drlearner.DRLearner` takes as input parameter
+    for each non-baseline treatment t. The :class:`.DRLearner` takes as input parameter
     ``model_final``, which is any scikit-learn regressor that is internally used to solve this multi-task
     regresion problem. If the parameter ``multitask_model_final`` is False, then this model is assumed
     to be a mono-task regressor, and separate clones of it are used to solve each regression target
@@ -98,7 +98,7 @@ class DRLearner(_OrthoLearner):
         Estimator for E[Y | X, W, T]. Trained by regressing Y on (features, controls, one-hot-encoded treatments)
         concatenated. The one-hot-encoding excludes the baseline treatment. Must implement `fit` and
         `predict` methods. If different models per treatment arm are desired, see the
-        :class:`~econml.utilities.MultiModelWrapper` helper class.
+        :class:`.MultiModelWrapper` helper class.
 
     model_final :
         estimator for the final cate model. Trained on regressing the doubly robust potential outcomes
@@ -337,7 +337,7 @@ class DRLearner(_OrthoLearner):
 
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, inference=None):
         """
-        Estimate the counterfactual model from data, i.e. estimates function: math: `\\theta(\\cdot)`.
+        Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
 
         Parameters
         ----------
@@ -496,7 +496,7 @@ class DRLearner(_OrthoLearner):
 
 class LinearDRLearner(StatsModelsCateEstimatorDiscreteMixin, DRLearner):
     """
-    Special case of the :class:`~econml.drlearner.DRLearner` where the final stage
+    Special case of the :class:`.DRLearner` where the final stage
     is a Linear Regression on a low dimensional set of features. In this case, inference
     can be performed via the asymptotic normal characterization of the estimated parameters.
     This is computationally faster than bootstrap inference. Set ``inference='statsmodels'``
@@ -518,7 +518,7 @@ class LinearDRLearner(StatsModelsCateEstimatorDiscreteMixin, DRLearner):
 
     Then inference can be performed via standard approaches for inference of OLS, via asympotic normal approximations
     of the estimated parameters. The default covariance estimator used is heteroskedasticity robust (HC1).
-    For other methods see :class:`~econml.inference.StatsModelsInferenceDiscrete`. Use can invoke them by setting:
+    For other methods see :class:`.StatsModelsInferenceDiscrete`. Use can invoke them by setting:
     ``inference=StatsModelsInferenceDiscrete(cov_type=...)``.
 
     This approach is valid even if the CATE model is not linear in :math:`\\phi(X)`. In this case it performs
@@ -535,7 +535,7 @@ class LinearDRLearner(StatsModelsCateEstimatorDiscreteMixin, DRLearner):
         Estimator for E[Y | X, W, T]. Trained by regressing Y on (features, controls, one-hot-encoded treatments)
         concatenated. The one-hot-encoding excludes the baseline treatment. Must implement `fit` and
         `predict` methods. If different models per treatment arm are desired, see the
-        :class:`~econml.utilities.MultiModelWrapper` helper class.
+        :class:`.MultiModelWrapper` helper class.
 
     featurizer : :term:`transformer`, optional, default None
         Must support fit_transform and transform. Used to create composite features in the final CATE regression.
@@ -628,7 +628,7 @@ class LinearDRLearner(StatsModelsCateEstimatorDiscreteMixin, DRLearner):
 
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, inference=None):
         """
-        Estimate the counterfactual model from data, i.e. estimates function: math: `\\theta(\\cdot)`.
+        Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
 
         Parameters
         ----------
@@ -673,7 +673,7 @@ class LinearDRLearner(StatsModelsCateEstimatorDiscreteMixin, DRLearner):
 
 class SparseLinearDRLearner(DebiasedLassoCateEstimatorDiscreteMixin, DRLearner):
     """
-    Special case of the :class:`~econml.drlearner.DRLearner` where the final stage
+    Special case of the :class:`.DRLearner` where the final stage
     is a Debiased Lasso Regression. In this case, inference can be performed via the debiased lasso approach
     and its asymptotic normal characterization of the estimated parameters. This is computationally
     faster than bootstrap inference. Set ``inference='debiasedlasso'`` at fit time, to enable inference
@@ -712,7 +712,7 @@ class SparseLinearDRLearner(DebiasedLassoCateEstimatorDiscreteMixin, DRLearner):
         Estimator for E[Y | X, W, T]. Trained by regressing Y on (features, controls, one-hot-encoded treatments)
         concatenated. The one-hot-encoding excludes the baseline treatment. Must implement `fit` and
         `predict` methods. If different models per treatment arm are desired, see the
-        :class:`~econml.utilities.MultiModelWrapper` helper class.
+        :class:`.MultiModelWrapper` helper class.
 
     featurizer : :term:`transformer`, optional, default None
         Must support fit_transform and transform. Used to create composite features in the final CATE regression.
@@ -827,7 +827,7 @@ class SparseLinearDRLearner(DebiasedLassoCateEstimatorDiscreteMixin, DRLearner):
 
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, inference=None):
         """
-        Estimate the counterfactual model from data, i.e. estimates function: math: `\\theta(\\cdot)`.
+        Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
 
         Parameters
         ----------

--- a/econml/ortho_forest.py
+++ b/econml/ortho_forest.py
@@ -591,7 +591,7 @@ class DiscreteTreatmentOrthoForest(BaseOrthoForest):
     model_Y :  estimator, optional (default=sklearn.linear_model.LassoCV(cv=3))
         Estimator for learning potential outcomes at each leaf.
         Will be trained on features, controls and one hot encoded treatments (concatenated).
-        If different models per treatment arm are desired, see the :py:class:`~econml.utilities.MultiModelWrapper`
+        If different models per treatment arm are desired, see the :class:`.MultiModelWrapper`
         helper class. The model(s) must implement `fit` and `predict` methods.
 
     propensity_model_final : estimator, optional (default=None)
@@ -602,7 +602,7 @@ class DiscreteTreatmentOrthoForest(BaseOrthoForest):
     model_Y_final : estimator, optional (default=None)
         Estimator for learning potential outcomes at prediction time.
         Will be trained on features, controls and one hot encoded treatments (concatenated).
-        If different models per treatment arm are desired, see the :py:class:`~econml.utilities.MultiModelWrapper`
+        If different models per treatment arm are desired, see the :class:`.MultiModelWrapper`
         helper class. The model(s) must implement `fit` and `predict` methods.
         If parameter is set to ``None``, it defaults to the value of `model_Y` parameter.
 

--- a/econml/sklearn_extensions/linear_model.py
+++ b/econml/sklearn_extensions/linear_model.py
@@ -1,7 +1,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""Collection of scikit-learn extensions for linear models."""
+"""Collection of scikit-learn extensions for linear models.
+
+.. testcode::
+    :hide:
+
+    # Our classes that derive from sklearn ones sometimes include
+    # inherited docstrings that have embedded doctests; we need the following imports
+    # so that they don't break.
+
+    import numpy as np
+    from sklearn.linear_model import lasso_path
+"""
 
 import numbers
 import numpy as np
@@ -531,19 +542,19 @@ class DebiasedLasso(WeightedLasso):
 
     Parameters
     ----------
-    alpha : string | float, optional. Default='auto'.
+    alpha : string | float, optional, default 'auto'.
         Constant that multiplies the L1 term. Defaults to 'auto'.
         ``alpha = 0`` is equivalent to an ordinary least square, solved
         by the :class:`LinearRegression` object. For numerical
         reasons, using ``alpha = 0`` with the ``Lasso`` object is not advised.
-        Given this, you should use the :class:`LinearRegression` object.
+        Given this, you should use the :class:`.LinearRegression` object.
 
     fit_intercept : boolean, optional, default True
         Whether to calculate the intercept for this model. If set
         to False, no intercept will be used in calculations
         (e.g. data is expected to be already centered).
 
-    precompute : True | False | array-like, default=False
+    precompute : True | False | array-like, default False
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument. For sparse input
@@ -596,10 +607,10 @@ class DebiasedLasso(WeightedLasso):
         Penalty chosen through cross-validation, if alpha='auto'.
 
     coef_std_err_ : array, shape (n_features,)
-        Estimated standard errors for coefficients (see 'coef_' attribute).
+        Estimated standard errors for coefficients (see ``coef_`` attribute).
 
     intercept_std_err_ : float
-        Estimated standard error intercept (see 'intercept_' attribute).
+        Estimated standard error intercept (see ``intercept_`` attribute).
 
     """
 
@@ -908,11 +919,11 @@ class MultiOutputDebiasedLasso(MultiOutputRegressor):
     selected_alpha_ : array, shape (n_targets, ) or float
         Penalty chosen through cross-validation, if alpha='auto'.
 
-    coef_std_err_ : array, shape (n_targets, n_features) or (n_features_, )
-        Estimated standard errors for coefficients (see 'coef_' attribute).
+    coef_std_err_ : array, shape (n_targets, n_features) or (n_features, )
+        Estimated standard errors for coefficients (see ``coef_`` attribute).
 
     intercept_std_err_ : array, shape (n_targets, ) or float
-        Estimated standard error intercept (see 'intercept_' attribute).
+        Estimated standard error intercept (see ``intercept_`` attribute).
 
     """
 

--- a/econml/utilities.py
+++ b/econml/utilities.py
@@ -1,20 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""
-Utility methods.
-
-.. testcode::
-    :hide:
-
-    # Our classes that derive from sklearn ones sometimes include
-    # inherited docstrings that have embedded doctests; we need the following imports
-    # so that they don't break.
-
-    import numpy as np
-    from sklearn.linear_model import lasso_path
-
-"""
+"""Utility methods."""
 
 import numpy as np
 import scipy.sparse


### PR DESCRIPTION
* We forgot to include the `sklearn_extensions` modules.
* Used a more consistent cross-reference style everywhere
* Fixed a few other miscellaneous doc issues (spelling, invalid cross refs, etc.)