### PR TITLE
Pin sklearn < 0.22

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ setup_requires =
 install_requires = 
     numpy
     scipy
-    scikit-learn >= 0.20.0
+    scikit-learn >= 0.20.0, <0.22
     keras
     sparse
     tensorflow == 1.*


### PR DESCRIPTION
The new release of sklearn breaks lots of things, so I'm pinning our requirement to sklearn < 0.22 for now.