### PR TITLE
Changed logic in summary_frame for feature names

### DIFF
--- a/econml/cate_estimator.py
+++ b/econml/cate_estimator.py
@@ -707,6 +707,8 @@ class LinearModelFinalCateEstimatorDiscreteMixin(BaseCateEstimator):
         -------
         intercept: float or (n_y,) array like
         """
+        if not self.fit_cate_intercept:
+            raise AttributeError("No intercept was fitted!")
         _, T = self._expand_treatments(None, T)
         ind = inverse_onehot(T).item() - 1
         assert ind >= 0, "No model was fitted for the control"

--- a/econml/inference.py
+++ b/econml/inference.py
@@ -637,8 +637,10 @@ class InferenceResults(metaclass=abc.ABCMeta):
         if self.d_y == 1:
             res.index = res.index.droplevel(1)
         if self.inf_type == 'coefficient':
+            if self.fname_transformer is not None:
+                feat_name = self.fname_transformer(feat_name)
             if feat_name is not None:
-                ind = self.fname_transformer(feat_name)
+                ind = feat_name
             else:
                 ct = res.shape[0] // self.d_y
                 ind = ['X' + str(i) for i in range(ct)]


### PR DESCRIPTION
Changed logic of feature names in summary_frame and added corresponding tests. Fixed a small bug in LinearModelFinalCateEstimatorDiscreteMixin where we werenot checking in intercept_ whether an intercept was fitted and raising an Attribute error if so. This lead to a weird error being raised because we were trying to reshape an integer.

Addressing #303 