### PR TITLE
Deprecate positional arguments to fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ To install from source, see [For Developers](#for-developers) section below.
 
   est = LinearDML(model_y=LassoCV(), model_t=LassoCV())
   ### Estimate with OLS confidence intervals
-  est.fit(Y, T, X, W) # W -> high-dimensional confounders, X -> features
+  est.fit(Y, T, X=X, W=W) # W -> high-dimensional confounders, X -> features
   treatment_effects = est.effect(X_test)
   lb, ub = est.effect_interval(X_test, alpha=0.05) # OLS confidence intervals
 
   ### Estimate with bootstrap confidence intervals
-  est.fit(Y, T, X, W, inference='bootstrap')  # with default bootstrap parameters
-  est.fit(Y, T, X, W, inference=BootstrapInference(n_bootstrap_samples=100))  # or customized
+  est.fit(Y, T, X=X, W=W, inference='bootstrap')  # with default bootstrap parameters
+  est.fit(Y, T, X=X, W=W, inference=BootstrapInference(n_bootstrap_samples=100))  # or customized
   lb, ub = est.effect_interval(X_test, alpha=0.05) # Bootstrap confidence intervals
   ```
 
@@ -157,7 +157,7 @@ To install from source, see [For Developers](#for-developers) section below.
   from sklearn.linear_model import LassoCV
 
   est = SparseLinearDML(model_y=LassoCV(), model_t=LassoCV())
-  est.fit(Y, T, X, W) # X -> high dimensional features
+  est.fit(Y, T, X=X, W=W) # X -> high dimensional features
   treatment_effects = est.effect(X_test)
   lb, ub = est.effect_interval(X_test, alpha=0.05) # Confidence intervals via debiased lasso
   ```
@@ -169,7 +169,7 @@ To install from source, see [For Developers](#for-developers) section below.
   from sklearn.ensemble import GradientBoostingRegressor
 
   est = ForestDML(model_y=GradientBoostingRegressor(), model_t=GradientBoostingRegressor())
-  est.fit(Y, T, X, W) 
+  est.fit(Y, T, X=X, W=W) 
   treatment_effects = est.effect(X_test)
   # Confidence intervals via Bootstrap-of-Little-Bags for forests
   lb, ub = est.effect_interval(X_test, alpha=0.05)
@@ -191,7 +191,7 @@ To install from source, see [For Developers](#for-developers) section below.
                                       lambda_reg=0.01,
                                       model_T=WeightedLasso(alpha=0.01), model_Y=WeightedLasso(alpha=0.01),
                                       model_T_final=WeightedLassoCV(cv=3), model_Y_final=WeightedLassoCV(cv=3))
-  est.fit(Y, T, X, W)
+  est.fit(Y, T, X=X, W=W)
   treatment_effects = est.effect(X_test)
   # Confidence intervals via Bootstrap-of-Little-Bags for forests
   lb, ub = est.effect_interval(X_test, alpha=0.05)
@@ -211,11 +211,11 @@ To install from source, see [For Developers](#for-developers) section below.
   est = XLearner(models=GradientBoostingRegressor(),
                 propensity_model=GradientBoostingClassifier(),
                 cate_models=GradientBoostingRegressor())
-  est.fit(Y, T, np.hstack([X, W]))
+  est.fit(Y, T, X=np.hstack([X, W]))
   treatment_effects = est.effect(np.hstack([X_test, W_test]))
 
   # Fit with bootstrap confidence interval construction enabled
-  est.fit(Y, T, np.hstack([X, W]), inference='bootstrap')
+  est.fit(Y, T, X=np.hstack([X, W]), inference='bootstrap')
   treatment_effects = est.effect(np.hstack([X_test, W_test]))
   lb, ub = est.effect_interval(np.hstack([X_test, W_test]), alpha=0.05) # Bootstrap CIs
   ```
@@ -227,7 +227,7 @@ To install from source, see [For Developers](#for-developers) section below.
   from sklearn.ensemble import GradientBoostingRegressor
 
   est = SLearner(overall_model=GradientBoostingRegressor())
-  est.fit(Y, T, np.hstack([X, W]))
+  est.fit(Y, T, X=np.hstack([X, W]))
   treatment_effects = est.effect(np.hstack([X_test, W_test]))
   ```
 
@@ -238,7 +238,7 @@ To install from source, see [For Developers](#for-developers) section below.
   from sklearn.ensemble import GradientBoostingRegressor
 
   est = TLearner(models=GradientBoostingRegressor())
-  est.fit(Y, T, np.hstack([X, W]))
+  est.fit(Y, T, X=np.hstack([X, W]))
   treatment_effects = est.effect(np.hstack([X_test, W_test]))
   ```
 </details>
@@ -255,7 +255,7 @@ from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifi
 
 est = LinearDRLearner(model_propensity=GradientBoostingClassifier(),
                       model_regression=GradientBoostingRegressor())
-est.fit(Y, T, X, W)
+est.fit(Y, T, X=X, W=W)
 treatment_effects = est.effect(X_test)
 lb, ub = est.effect_interval(X_test, alpha=0.05)
 ```
@@ -268,7 +268,7 @@ from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifi
 
 est = SparseLinearDRLearner(model_propensity=GradientBoostingClassifier(),
                             model_regression=GradientBoostingRegressor())
-est.fit(Y, T, X, W)
+est.fit(Y, T, X=X, W=W)
 treatment_effects = est.effect(X_test)
 lb, ub = est.effect_interval(X_test, alpha=0.05)
 ```
@@ -281,7 +281,7 @@ from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifi
 
 est = ForestDRLearner(model_propensity=GradientBoostingClassifier(),
                       model_regression=GradientBoostingRegressor())
-est.fit(Y, T, X, W) 
+est.fit(Y, T, X=X, W=W) 
 treatment_effects = est.effect(X_test)
 lb, ub = est.effect_interval(X_test, alpha=0.05)
 ```
@@ -300,7 +300,7 @@ from sklearn.linear_model import LinearRegression
 est = LinearIntentToTreatDRIV(model_Y_X=GradientBoostingRegressor(),
                               model_T_XZ=GradientBoostingClassifier(),
                               flexible_model_effect=GradientBoostingRegressor())
-est.fit(Y, T, Z, X) # OLS inference by default
+est.fit(Y, T, Z=Z, X=X) # OLS inference by default
 treatment_effects = est.effect(X_test)
 lb, ub = est.effect_interval(X_test, alpha=0.05) # OLS confidence intervals
 ```
@@ -332,7 +332,7 @@ est = DeepIVEstimator(n_components=10, # Number of gaussians in the mixture dens
                       h=lambda t, x: response_model(keras.layers.concatenate([t, x])), # Response model
                       n_samples=1 # Number of samples used to estimate the response
                       )
-est.fit(Y, T, X, Z) # Z -> instrumental variables
+est.fit(Y, T, X=X, Z=Z) # Z -> instrumental variables
 treatment_effects = est.effect(X_test)
 ```
 </details>

--- a/doc/spec/api.rst
+++ b/doc/spec/api.rst
@@ -278,7 +278,7 @@ We can run the following:
 
     # Fit counterfactual model 
     cfest = BaseCateEstimator()
-    cfest.fit(y, T, X, W, Z, inference='bootstrap')
+    cfest.fit(y, T, X=X, W=W, Z=Z, inference='bootstrap')
 
 Suppose now that we wanted to estimate the conditional average treatment effect for every point :math:`X_i` 
 in the training data and between treatment 1 and treatment 0. 

--- a/doc/spec/estimation/dml.rst
+++ b/doc/spec/estimation/dml.rst
@@ -62,7 +62,7 @@ characteristics :math:`X` of the treated samples, then one can use this method. 
 
     from econml.dml import LinearDML
     est = LinearDML()
-    est.fit(y, T, X, W)
+    est.fit(y, T, X=X, W=W)
     est.const_marginal_effect(X)
 
 This way an optimal treatment policy can be learned, by simply inspecting for which :math:`X` the effect was positive.
@@ -212,7 +212,7 @@ Below we give a brief description of each of these classes:
           .. testcode::
 
             est = LinearDML()
-            est.fit(y, T, X, W)
+            est.fit(y, T, X=X, W=W)
             point = est.effect(X, T0=T0, T1=T1)
             lb, ub = est.effect_interval(X, T0=T0, T1=T1, alpha=0.05)
 
@@ -229,7 +229,7 @@ Below we give a brief description of each of these classes:
 
             from econml.dml import SparseLinearDML
             est = SparseLinearDML()
-            est.fit(y, T, X, W)
+            est.fit(y, T, X=X, W=W)
             point = est.effect(X, T0=T0, T1=T1)
             lb, ub = est.effect_interval(X, T0=T0, T1=T1, alpha=0.05)
 
@@ -257,7 +257,7 @@ Below we give a brief description of each of these classes:
         est = NonParamDML(model_y=GradientBoostingRegressor(),
                                        model_t=GradientBoostingRegressor(),    
                                        model_final=GradientBoostingRegressor())
-        est.fit(y, t, X, W)
+        est.fit(y, t, X=X, W=W)
         point = est.effect(X, T0=t0, T1=t1)    
 
       Examples include Random Forests (:class:`~sklearn.ensemble.RandomForestRegressor`), Gradient Boosted Forests (:class:`~sklearn.ensemble.GradientBoostingRegressor`) and
@@ -279,7 +279,7 @@ Below we give a brief description of each of these classes:
             from sklearn.ensemble import GradientBoostingRegressor
             est = ForestDML(model_y=GradientBoostingRegressor(),
                                          model_t=GradientBoostingRegressor())
-            est.fit(y, t, X, W)
+            est.fit(y, t, X=X, W=W)
             point = est.effect(X, T0=t0, T1=t1)
             lb, ub = est.effect_interval(X, T0=t0, T1=t1, alpha=0.05)
 
@@ -314,7 +314,7 @@ Usage FAQs
 
         from econml.dml import LinearDML
         est = LinearDML()
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         lb, ub = est.const_marginal_effect_interval(X, alpha=.05)
         lb, ub = est.coef__interval(alpha=.05)
         lb, ub = est.effect_interval(X, T0=T0, T1=T1, alpha=.05)
@@ -375,7 +375,7 @@ Usage FAQs
         from econml.dml import SparseLinearDML
         from sklearn.preprocessing import PolynomialFeatures
         est = SparseLinearDML(featurizer=PolynomialFeatures(degree=4, include_bias=False))
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         lb, ub = est.const_marginal_effect_interval(X, alpha=.05)
     
     Alternatively, you can also use a forest based estimator such as :class:`.ForestDML`. This 
@@ -388,7 +388,7 @@ Usage FAQs
         from sklearn.ensemble import GradientBoostingRegressor
         est = ForestDML(model_y=GradientBoostingRegressor(),
                                      model_t=GradientBoostingRegressor())
-        est.fit(y, t, X, W)
+        est.fit(y, t, X=X, W=W)
         lb, ub = est.const_marginal_effect_interval(X, alpha=.05)
     
     Also the check out the :ref:`Orthogonal Random Forest User Guide <orthoforestuserguide>` or the
@@ -456,7 +456,7 @@ Usage FAQs
         est = DML(model_y=GradientBoostingRegressor(),
                                model_t=GradientBoostingRegressor(),
                                model_final=ElasticNetCV())
-        est.fit(y, t, X, W)
+        est.fit(y, t, X=X, W=W)
         point = est.const_marginal_effect(X)
         point = est.effect(X, T0=t0, T1=t1)
     
@@ -492,7 +492,7 @@ Usage FAQs
         poly = PolynomialFeatures(degree=2, interaction_only=True, include_bias=False)
         est = LinearDML()
         T_composite = poly.fit_transform(T)
-        est.fit(y, T_composite, X, W)
+        est.fit(y, T_composite, X=X, W=W)
         point = est.const_marginal_effect(X)
         est.effect(X, T0=poly.transform(T0), T1=poly.transform(T1)) 
 
@@ -514,7 +514,7 @@ Usage FAQs
         from econml.dml import LinearDML
         from sklearn.linear_model import LogisticRegressionCV
         est = LinearDML(model_t=LogisticRegressionCV(), discrete_treatment=True)
-        est.fit(y, t, X, W)
+        est.fit(y, t, X=X, W=W)
         point = est.const_marginal_effect(X)
         est.effect(X, T0=t0, T1=t1)
 
@@ -531,7 +531,7 @@ Usage FAQs
         est = DML(model_y=RandomForestRegressor(oob_score=True),
                                model_t=RandomForestRegressor(oob_score=True),
                                model_final=ElasticNetCV(), featurizer=PolynomialFeatures(degree=1))
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         est.score_
 
     This essentially measures the score based on the final stage loss. Moreover, one can assess the out-of-sample score by calling the `score` method on a separate validation sample that was not
@@ -580,7 +580,7 @@ A classical non-parametric regressor for the first stage estimates is a Random F
     from sklearn.ensemble import RandomForestRegressor
     est = LinearDML(model_y=RandomForestRegressor(),
                                  model_t=RandomForestRegressor())
-    est.fit(y, T, X, W)
+    est.fit(y, T, X=X, W=W)
     pnt_effect = est.const_marginal_effect(X)
     lb_effect, ub_effect = est.const_marginal_effect_interval(X, alpha=.05)
     pnt_coef = est.coef_
@@ -604,7 +604,7 @@ Then we can estimate the coefficients :math:`\alpha_i` by running:
     est = LinearDML(model_y=RandomForestRegressor(),
                                  model_t=RandomForestRegressor(),
                                  featurizer=PolynomialFeatures(degree=4, include_bias=True))
-    est.fit(y, T, X, W)
+    est.fit(y, T, X=X, W=W)
 
     # To get the coefficients of the polynomial fitted in the final stage we can
     # access the `coef_` attribute of the fitted second stage model. This would 
@@ -624,7 +624,7 @@ To add fixed effect heterogeneity, we can create one-hot encodings of the id, wh
 
     est = LinearDML(model_y=RandomForestRegressor(),
                                  model_t=RandomForestRegressor())
-    est.fit(y, T, X_oh, W)
+    est.fit(y, T, X=X_oh, W=W)
     # The latter will fit a model for θ(x) of the form ̂α_0 + ̂α_1 𝟙{id=1} + ̂α_2 𝟙{id=2} + ...
     # The vector of α can be extracted as follows
     est.coef_
@@ -647,7 +647,7 @@ One can also define a custom featurizer, as long as it supports the fit\_transfo
     est = LinearDML(model_y=RandomForestRegressor(),
                                 model_t=RandomForestRegressor(),
                                 featurizer=LogFeatures())
-    est.fit(y, T, X, W)
+    est.fit(y, T, X=X, W=W)
 
 We can even create a Pipeline or Union of featurizers that will apply multiply featurizations, e.g. first creating log features and then adding polynomials of them:
 
@@ -661,7 +661,7 @@ We can even create a Pipeline or Union of featurizers that will apply multiply f
                                  model_t=RandomForestRegressor(),
                                  featurizer=Pipeline([('log', LogFeatures()), 
                                                       ('poly', PolynomialFeatures(degree=3))]))
-    est.fit(y, T, X, W)
+    est.fit(y, T, X=X, W=W)
 
 
 .. rubric:: Single Outcome, Multiple Treatments
@@ -673,7 +673,7 @@ Then we could expand the treatment vector to contain also polynomial features:
 
     import numpy as np
     est = LinearDML()
-    est.fit(y, np.concatenate((T, T**2), axis=1), X, W)
+    est.fit(y, np.concatenate((T, T**2), axis=1), X=X, W=W)
 
 .. rubric:: Multiple Outcome, Multiple Treatments
 
@@ -685,7 +685,7 @@ matrix of cross price elasticities as:
     from sklearn.linear_model import MultiTaskElasticNet
     est = LinearDML(model_y=MultiTaskElasticNet(alpha=0.1),
                                  model_t=MultiTaskElasticNet(alpha=0.1))
-    est.fit(Y, T, None, W)
+    est.fit(Y, T, X=None, W=W)
 
     # a_hat[i,j] contains the elasticity of the demand of product i on the price of product j
     a_hat = est.const_marginal_effect()
@@ -708,7 +708,7 @@ lightning package implements such a class::
                            model_t=MultiTaskElasticNet(alpha=0.1),
                            model_final=FistaRegressor(penalty='trace', C=0.0001),
                            fit_cate_intercept=False)
-    est.fit(Y, T, X, W)
+    est.fit(Y, T, X=X, W=W)
     te_pred = est.const_marginal_effect(np.median(X, axis=0, keepdims=True))
     print(te_pred)
     print(np.linalg.svd(te_pred[0]))

--- a/doc/spec/estimation/dr.rst
+++ b/doc/spec/estimation/dr.rst
@@ -70,7 +70,7 @@ characteristics :math:`X` of the treated samples, then one can use this method. 
 
     from econml.drlearner import LinearDRLearner
     est = LinearDRLearner()
-    est.fit(y, T, X, W)
+    est.fit(y, T, X=X, W=W)
     est.effect(X, T0=t0, T1=t1)
 
 This way an optimal treatment policy can be learned, by simply inspecting for which :math:`X` the effect was positive.
@@ -214,7 +214,7 @@ Below we give a brief description of each of these classes:
         est = DRLearner(model_regression=GradientBoostingRegressor(),
                         model_propensity=GradientBoostingClassifier(),
                         model_final=GradientBoostingRegressor())
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         point = est.effect(X, T0=T0, T1=T1)
 
       Examples of models include Random Forests (:class:`~sklearn.ensemble.RandomForestRegressor`),
@@ -243,7 +243,7 @@ Below we give a brief description of each of these classes:
                         )
         est = DRLearner(model_regression=model_reg(), model_propensity=model_clf(),
                         model_final=model_reg(), n_splits=5)
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         point = est.effect(X, T0=T0, T1=T1)
 
       From that respect this estimator is also a *Meta-Learner*, since all steps of the estimation use out-of-the-box ML algorithms. For more information,
@@ -262,7 +262,7 @@ Below we give a brief description of each of these classes:
 
             from econml.drlearner import LinearDRLearner
             est = LinearDRLearner()
-            est.fit(y, T, X, W)
+            est.fit(y, T, X=X, W=W)
             point = est.effect(X, T1=t1)
             lb, ub = est.effect_interval(X, T1=t1, alpha=0.05)
             # Get CATE for all treatments
@@ -283,7 +283,7 @@ Below we give a brief description of each of these classes:
 
             from econml.drlearner import SparseLinearDRLearner
             est = SparseLinearDRLearner()
-            est.fit(y, T, X, W)
+            est.fit(y, T, X=X, W=W)
             point = est.effect(X, T1=T1)
             lb, ub = est.effect_interval(X, T1=T1, alpha=0.05)
             # Get CATE for all treatments
@@ -302,7 +302,7 @@ Below we give a brief description of each of these classes:
             from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifier
             est = ForestDRLearner(model_regression=GradientBoostingRegressor(),
                                   model_propensity=GradientBoostingClassifier())
-            est.fit(y, T, X, W)
+            est.fit(y, T, X=X, W=W)
             point = est.effect(X, T0=T0, T1=T1)
             lb, ub = est.effect_interval(X, T0=T0, T1=T1, alpha=0.05)
 
@@ -325,7 +325,7 @@ Usage FAQs
 
         from econml.drlearner import LinearDRLearner
         est = LinearDRLearner()
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         lb, ub = est.const_marginal_effect_interval(X, alpha=.05)
         lb, ub = est.coef__interval(T=1, alpha=.05)
         lb, ub = est.effect_interval(X, T0=T0, T1=T1, alpha=.05)
@@ -344,7 +344,7 @@ Usage FAQs
         from econml.drlearner import SparseLinearDRLearner
         from sklearn.preprocessing import PolynomialFeatures
         est = SparseLinearDRLearner(featurizer=PolynomialFeatures(degree=3, include_bias=False))
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         lb, ub = est.const_marginal_effect_interval(X, alpha=.05)
         lb, ub = est.coef__interval(T=1, alpha=.05)
         lb, ub = est.effect_interval(X, T0=T0, T1=T1, alpha=.05)
@@ -359,7 +359,7 @@ Usage FAQs
         from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifier
         est = ForestDRLearner(model_regression=GradientBoostingRegressor(),
                               model_propensity=GradientBoostingClassifier())
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         point = est.effect(X, T0=T0, T1=T1)
         lb, ub = est.effect_interval(X, T0=T0, T1=T1, alpha=0.05)
         lb, ub = est.const_marginal_effect_interval(X, alpha=0.05)
@@ -428,7 +428,7 @@ Usage FAQs
                         )
         est = DRLearner(model_regression=model_reg(), model_propensity=model_clf(),
                         model_final=model_reg(), n_splits=5)
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         point = est.effect(X, T0=T0, T1=T1)
 
 - **What if I have many treatments?**
@@ -447,7 +447,7 @@ Usage FAQs
         est = DRLearner(model_regression=RandomForestRegressor(oob_score=True),
                         model_propensity=RandomForestClassifier(min_samples_leaf=10, oob_score=True),
                         model_final=RandomForestRegressor())
-        est.fit(y, T, X, W)
+        est.fit(y, T, X=X, W=W)
         est.score_
 
     This essentially measures the score based on the final stage loss. Moreover, one can assess the out-of-sample score by calling the `score` method on a separate validation sample that was not

--- a/doc/spec/estimation/forest.rst
+++ b/doc/spec/estimation/forest.rst
@@ -360,7 +360,7 @@ and the `ForestLearners Jupyter notebook <https://github.com/microsoft/EconML/bl
     >>> est = ContinuousTreatmentOrthoForest(n_trees=1, max_depth=1, subsample_ratio=1,
     ...                                      model_T=sklearn.linear_model.LinearRegression(),
     ...                                      model_Y=sklearn.linear_model.LinearRegression())
-    >>> est.fit(Y, T, W, W)
+    >>> est.fit(Y, T, X=W, W=W)
     <econml.ortho_forest.ContinuousTreatmentOrthoForest object at 0x...>
     >>> print(est.effect(W[:2]))
     [1.00...  1.19...]
@@ -373,7 +373,7 @@ Similarly, we can call :class:`.DiscreteTreatmentOrthoForest`:
     >>> est = DiscreteTreatmentOrthoForest(n_trees=1, max_depth=1, subsample_ratio=1,
     ...                                    propensity_model=sklearn.linear_model.LogisticRegression(),
     ...                                    model_Y=sklearn.linear_model.LinearRegression())
-    >>> est.fit(Y, T, W, W)
+    >>> est.fit(Y, T, X=W, W=W)
     <econml.ortho_forest.DiscreteTreatmentOrthoForest object at 0x...>
     >>> print(est.effect(W[:2]))
     [0.99...  1.35...]
@@ -397,7 +397,7 @@ both the treatment and the outcome regressions, in the case of continuous treatm
     ...                                     max_depth=5,
     ...                                     model_Y=WeightedLasso(alpha=0.01),
     ...                                     model_T=WeightedLasso(alpha=0.01))
-    >>> est.fit(Y, T, X, W)
+    >>> est.fit(Y, T, X=X, W=W)
     <econml.ortho_forest.ContinuousTreatmentOrthoForest object at 0x...>
     >>> X_test = np.linspace(-1, 1, 30).reshape(-1, 1)
     >>> treatment_effects = est.effect(X_test)

--- a/doc/spec/inference.rst
+++ b/doc/spec/inference.rst
@@ -32,7 +32,7 @@ For instance:
     est = NonParamDML(model_y=RandomForestRegressor(n_estimators=10, min_samples_leaf=10),
                                 model_t=RandomForestRegressor(n_estimators=10, min_samples_leaf=10),
                                 model_final=RandomForestRegressor(n_estimators=10, min_samples_leaf=10))
-    est.fit(y, t, X, W, inference='bootstrap')
+    est.fit(y, t, X=X, W=W, inference='bootstrap')
     point = est.const_marginal_effect(X)
     lb, ub = est.const_marginal_effect_interval(X, alpha=0.05)
 
@@ -54,7 +54,7 @@ This for instance holds for the :class:`.LinearDML` and the :class:`.LinearDRLea
     from sklearn.ensemble import RandomForestRegressor
     est = LinearDML(model_y=RandomForestRegressor(n_estimators=10, min_samples_leaf=10),
                                  model_t=RandomForestRegressor(n_estimators=10, min_samples_leaf=10))
-    est.fit(y, t, X, W)
+    est.fit(y, t, X=X, W=W)
     point = est.const_marginal_effect(X)
     lb, ub = est.const_marginal_effect_interval(X, alpha=0.05)
 
@@ -64,7 +64,7 @@ This for instance holds for the :class:`.LinearDML` and the :class:`.LinearDRLea
     from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
     est = LinearDRLearner(model_regression=RandomForestRegressor(n_estimators=10, min_samples_leaf=10),
                           model_propensity=RandomForestClassifier(n_estimators=10, min_samples_leaf=10))
-    est.fit(y, t, X, W)
+    est.fit(y, t, X=X, W=W)
     point = est.effect(X)
     lb, ub = est.effect_interval(X, alpha=0.05)
 
@@ -86,7 +86,7 @@ explicitly setting ``inference='debiasedlasso'``, e.g.:
     from sklearn.ensemble import RandomForestRegressor
     est = SparseLinearDML(model_y=RandomForestRegressor(n_estimators=10, min_samples_leaf=10),
                                        model_t=RandomForestRegressor(n_estimators=10, min_samples_leaf=10))
-    est.fit(y, t, X, W)
+    est.fit(y, t, X=X, W=W)
     point = est.const_marginal_effect(X)
     lb, ub = est.const_marginal_effect_interval(X, alpha=0.05)
 
@@ -96,7 +96,7 @@ explicitly setting ``inference='debiasedlasso'``, e.g.:
     from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
     est = SparseLinearDRLearner(model_regression=RandomForestRegressor(n_estimators=10, min_samples_leaf=10),
                                 model_propensity=RandomForestClassifier(n_estimators=10, min_samples_leaf=10))
-    est.fit(y, t, X, W)
+    est.fit(y, t, X=X, W=W)
     point = est.effect(X)
     lb, ub = est.effect_interval(X, alpha=0.05)
 
@@ -120,7 +120,7 @@ or by explicitly setting ``inference='blb'``, e.g.:
     from sklearn.ensemble import RandomForestRegressor
     est = ForestDML(model_y=RandomForestRegressor(n_estimators=10, min_samples_leaf=10),
                                  model_t=RandomForestRegressor(n_estimators=10, min_samples_leaf=10))
-    est.fit(y, t, X, W)
+    est.fit(y, t, X=X, W=W)
     point = est.const_marginal_effect(X)
     lb, ub = est.const_marginal_effect_interval(X, alpha=0.05)
 
@@ -130,7 +130,7 @@ or by explicitly setting ``inference='blb'``, e.g.:
     from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
     est = ForestDRLearner(model_regression=RandomForestRegressor(n_estimators=10, min_samples_leaf=10),
                           model_propensity=RandomForestClassifier(n_estimators=10, min_samples_leaf=10))
-    est.fit(y, t, X, W)
+    est.fit(y, t, X=X, W=W)
     point = est.effect(X)
     lb, ub = est.effect_interval(X, alpha=0.05)
 
@@ -154,7 +154,7 @@ inference at its default setting of ``'auto'`` or by explicitly setting ``infere
                                          min_leaf_size=3,
                                          model_T=WeightedLasso(alpha=0.01),
                                          model_Y=WeightedLasso(alpha=0.01))
-    est.fit(y, t, X, W)
+    est.fit(y, t, X=X, W=W)
     point = est.const_marginal_effect(X)
     lb, ub = est.const_marginal_effect_interval(X, alpha=0.05)
 

--- a/econml/_ortho_learner.py
+++ b/econml/_ortho_learner.py
@@ -29,7 +29,7 @@ import copy
 from warnings import warn
 from .utilities import (shape, reshape, ndim, hstack, cross_product, transpose, inverse_onehot,
                         broadcast_unit_treatments, reshape_treatmentwise_effects, filter_none_kwargs,
-                        StatsModelsLinearRegression, _EncoderWrapper)
+                        _deprecate_positional, StatsModelsLinearRegression, _EncoderWrapper)
 from sklearn.model_selection import KFold, StratifiedKFold, check_cv
 from sklearn.linear_model import LinearRegression, LassoCV
 from sklearn.preprocessing import (PolynomialFeatures, LabelEncoder, OneHotEncoder,
@@ -502,8 +502,10 @@ class _OrthoLearner(TreatmentExpansionMixin, LinearCateEstimator):
         else:
             return None
 
+    @_deprecate_positional("X, W, and Z should be passed by keyword only. In a future release "
+                           "we will disallow passing X, W, and Z by position.", ['X', 'W', 'Z'])
     @BaseCateEstimator._wrap_fit
-    def fit(self, Y, T, X=None, W=None, Z=None, sample_weight=None, sample_var=None, groups=None, *, inference=None):
+    def fit(self, Y, T, X=None, W=None, Z=None, *, sample_weight=None, sample_var=None, groups=None, inference=None):
         """
         Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
 

--- a/econml/_rlearner.py
+++ b/econml/_rlearner.py
@@ -28,7 +28,7 @@ Chernozhukov et al. (2017). Double/debiased machine learning for treatment and s
 import numpy as np
 import copy
 from warnings import warn
-from .utilities import (shape, reshape, ndim, hstack, filter_none_kwargs)
+from .utilities import (shape, reshape, ndim, hstack, filter_none_kwargs, _deprecate_positional)
 from sklearn.linear_model import LinearRegression
 from sklearn.base import clone
 from ._ortho_learner import _OrthoLearner
@@ -284,6 +284,8 @@ class _RLearner(_OrthoLearner):
                          n_splits=n_splits,
                          random_state=random_state)
 
+    @_deprecate_positional("X, and should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference=None):
         """
         Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.

--- a/econml/deepiv.py
+++ b/econml/deepiv.py
@@ -10,7 +10,7 @@ from .utilities import deprecated
 from keras import backend as K
 import keras.layers as L
 from keras.models import Model
-from econml.utilities import check_input_arrays
+from econml.utilities import check_input_arrays, _deprecate_positional
 
 # TODO: make sure to use random seeds wherever necessary
 # TODO: make sure that the public API consistently uses "T" instead of "P" for the treatment
@@ -289,8 +289,10 @@ class DeepIV(BaseCateEstimator):
         self._second_stage_options = second_stage_options
         super().__init__()
 
+    @_deprecate_positional("X and Z should be passed by keyword only. In a future release "
+                           "we will disallow passing X and Z by position.", ['X', 'Z'])
     @BaseCateEstimator._wrap_fit
-    def fit(self, Y, T, X, Z, inference=None):
+    def fit(self, Y, T, X, Z, *, inference=None):
         """Estimate the counterfactual model from data.
 
         That is, estimate functions τ(·, ·, ·), ∂τ(·, ·).

--- a/econml/dml.py
+++ b/econml/dml.py
@@ -39,7 +39,7 @@ from warnings import warn
 from .utilities import (shape, reshape, ndim, hstack, cross_product, transpose, inverse_onehot,
                         broadcast_unit_treatments, reshape_treatmentwise_effects, add_intercept,
                         StatsModelsLinearRegression, LassoCVWrapper, check_high_dimensional, check_input_arrays,
-                        fit_with_groups, deprecated)
+                        fit_with_groups, deprecated, _deprecate_positional)
 from econml.sklearn_extensions.linear_model import MultiOutputDebiasedLasso, WeightedLassoCVWrapper
 from econml.sklearn_extensions.ensemble import SubsampledHonestForest
 from sklearn.model_selection import KFold, StratifiedKFold, check_cv
@@ -448,6 +448,8 @@ class DML(LinearModelFinalCateEstimatorMixin, _BaseDML):
                          random_state=random_state)
 
     # override only so that we can update the docstring to indicate support for `StatsModelsInference`
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference='auto'):
         """
         Estimate the counterfactual model from data, i.e. estimates functions τ(·,·,·), ∂τ(·,·).
@@ -558,6 +560,8 @@ class LinearDML(StatsModelsCateEstimatorMixin, DML):
                          random_state=random_state)
 
     # override only so that we can update the docstring to indicate support for `StatsModelsInference`
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference='auto'):
         """
         Estimate the counterfactual model from data, i.e. estimates functions τ(·,·,·), ∂τ(·,·).
@@ -704,6 +708,8 @@ class SparseLinearDML(DebiasedLassoCateEstimatorMixin, DML):
                          n_splits=n_splits,
                          random_state=random_state)
 
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference='auto'):
         """
         Estimate the counterfactual model from data, i.e. estimates functions τ(·,·,·), ∂τ(·,·).
@@ -1105,6 +1111,8 @@ class ForestDML(ForestModelFinalCateEstimatorMixin, NonParamDML):
                          categories=categories,
                          n_splits=n_crossfit_splits, random_state=random_state)
 
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference='auto'):
         """
         Estimate the counterfactual model from data, i.e. estimates functions τ(·,·,·), ∂τ(·,·).

--- a/econml/drlearner.py
+++ b/econml/drlearner.py
@@ -32,7 +32,7 @@ from warnings import warn
 
 from sklearn.base import clone
 from sklearn.linear_model import LogisticRegressionCV, LinearRegression, LassoCV
-from econml.utilities import (inverse_onehot, check_high_dimensional,
+from econml.utilities import (inverse_onehot, check_high_dimensional, _deprecate_positional,
                               StatsModelsLinearRegression, check_input_arrays, fit_with_groups, filter_none_kwargs)
 from econml.sklearn_extensions.linear_model import WeightedLassoCVWrapper, DebiasedLasso
 from econml.sklearn_extensions.ensemble import SubsampledHonestForest
@@ -370,6 +370,8 @@ class DRLearner(_OrthoLearner):
                          categories=categories,
                          random_state=random_state)
 
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference=None):
         """
         Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
@@ -689,6 +691,8 @@ class LinearDRLearner(StatsModelsCateEstimatorDiscreteMixin, DRLearner):
                          n_splits=n_splits,
                          random_state=random_state)
 
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference='auto'):
         """
         Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
@@ -904,6 +908,8 @@ class SparseLinearDRLearner(DebiasedLassoCateEstimatorDiscreteMixin, DRLearner):
                          n_splits=n_splits,
                          random_state=random_state)
 
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference='auto'):
         """
         Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
@@ -1159,6 +1165,8 @@ class ForestDRLearner(ForestModelFinalCateEstimatorDiscreteMixin, DRLearner):
                          categories=categories,
                          n_splits=n_crossfit_splits, random_state=random_state)
 
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     def fit(self, Y, T, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference='auto'):
         """
         Estimate the counterfactual model from data, i.e. estimates functions τ(·,·,·), ∂τ(·,·).

--- a/econml/metalearners.py
+++ b/econml/metalearners.py
@@ -16,7 +16,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.utils import check_array, check_X_y
 from sklearn.preprocessing import OneHotEncoder, FunctionTransformer
 from .utilities import (check_inputs, check_models, broadcast_unit_treatments, reshape_treatmentwise_effects,
-                        inverse_onehot, transpose, _EncoderWrapper, check_input_arrays)
+                        inverse_onehot, transpose, _EncoderWrapper, check_input_arrays, _deprecate_positional)
 
 
 class TLearner(TreatmentExpansionMixin, LinearCateEstimator):
@@ -44,6 +44,8 @@ class TLearner(TreatmentExpansionMixin, LinearCateEstimator):
             validate=False)
         super().__init__()
 
+    @_deprecate_positional("X should be passed by keyword only. In a future release "
+                           "we will disallow passing X by position.", ['X'])
     @BaseCateEstimator._wrap_fit
     def fit(self, Y, T, X, *, inference=None):
         """Build an instance of TLearner.
@@ -132,6 +134,8 @@ class SLearner(TreatmentExpansionMixin, LinearCateEstimator):
             validate=False)
         super().__init__()
 
+    @_deprecate_positional("X should be passed by keyword only. In a future release "
+                           "we will disallow passing X by position.", ['X'])
     @BaseCateEstimator._wrap_fit
     def fit(self, Y, T, X=None, *, inference=None):
         """Build an instance of SLearner.
@@ -236,6 +240,8 @@ class XLearner(TreatmentExpansionMixin, LinearCateEstimator):
             validate=False)
         super().__init__()
 
+    @_deprecate_positional("X should be passed by keyword only. In a future release "
+                           "we will disallow passing X by position.", ['X'])
     @BaseCateEstimator._wrap_fit
     def fit(self, Y, T, X, *, inference=None):
         """Build an instance of XLearner.
@@ -361,6 +367,8 @@ class DomainAdaptationLearner(TreatmentExpansionMixin, LinearCateEstimator):
             validate=False)
         super().__init__()
 
+    @_deprecate_positional("X should be passed by keyword only. In a future release "
+                           "we will disallow passing X by position.", ['X'])
     @BaseCateEstimator._wrap_fit
     def fit(self, Y, T, X, *, inference=None):
         """Build an instance of DomainAdaptationLearner.

--- a/econml/ortho_forest.py
+++ b/econml/ortho_forest.py
@@ -552,7 +552,7 @@ class ContinuousTreatmentOrthoForest(BaseOrthoForest):
         -------
         self: an instance of self.
         """
-        return super().fit(Y, T, X, W=W, inference=inference)
+        return super().fit(Y, T, X=X, W=W, inference=inference)
 
     def const_marginal_effect(self, X):
         X = check_array(X)
@@ -844,7 +844,7 @@ class DiscreteTreatmentOrthoForest(BaseOrthoForest):
             func=_EncoderWrapper(self._one_hot_encoder).encode,
             validate=False)
         # Call `fit` from parent class
-        return super().fit(Y, T, X, W=W, inference=inference)
+        return super().fit(Y, T, X=X, W=W, inference=inference)
 
     @staticmethod
     def nuisance_estimator_generator(propensity_model, model_Y, n_T, random_state=None, second_stage=False):

--- a/econml/ortho_forest.py
+++ b/econml/ortho_forest.py
@@ -38,7 +38,7 @@ from .sklearn_extensions.linear_model import WeightedLassoCVWrapper
 from .cate_estimator import BaseCateEstimator, LinearCateEstimator, TreatmentExpansionMixin
 from .causal_tree import CausalTree
 from .inference import Inference
-from .utilities import (reshape, reshape_Y_T, MAX_RAND_SEED, check_inputs,
+from .utilities import (reshape, reshape_Y_T, MAX_RAND_SEED, check_inputs, _deprecate_positional,
                         cross_product, inverse_onehot, _EncoderWrapper, check_input_arrays)
 
 
@@ -184,8 +184,10 @@ class BaseOrthoForest(TreatmentExpansionMixin, LinearCateEstimator):
         self.model_is_fitted = False
         super().__init__()
 
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
     @BaseCateEstimator._wrap_fit
-    def fit(self, Y, T, X, W=None, inference='auto'):
+    def fit(self, Y, T, X, W=None, *, inference='auto'):
         """Build an orthogonal random forest from a training set (Y, T, X, W).
 
         Parameters
@@ -523,7 +525,9 @@ class ContinuousTreatmentOrthoForest(BaseOrthoForest):
 
     # Need to redefine fit here for auto inference to work due to a quirk in how
     # wrap_fit is defined
-    def fit(self, Y, T, X, W=None, inference='auto'):
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
+    def fit(self, Y, T, X, W=None, *, inference='auto'):
         """Build an orthogonal random forest from a training set (Y, T, X, W).
 
         Parameters
@@ -795,7 +799,9 @@ class DiscreteTreatmentOrthoForest(BaseOrthoForest):
             n_jobs=n_jobs,
             random_state=random_state)
 
-    def fit(self, Y, T, X, W=None, inference='auto'):
+    @_deprecate_positional("X and W should be passed by keyword only. In a future release "
+                           "we will disallow passing X and W by position.", ['X', 'W'])
+    def fit(self, Y, T, X, W=None, *, inference='auto'):
         """Build an orthogonal random forest from a training set (Y, T, X, W).
 
         Parameters

--- a/econml/ortho_iv.py
+++ b/econml/ortho_iv.py
@@ -21,7 +21,8 @@ from sklearn.pipeline import Pipeline
 
 from ._ortho_learner import _OrthoLearner
 from .dml import _FinalWrapper
-from .utilities import (hstack, StatsModelsLinearRegression, inverse_onehot, add_intercept, fit_with_groups)
+from .utilities import (hstack, StatsModelsLinearRegression, inverse_onehot,
+                        add_intercept, fit_with_groups, _deprecate_positional)
 from .inference import StatsModelsInference
 from .cate_estimator import StatsModelsCateEstimatorMixin
 
@@ -144,6 +145,8 @@ class _BaseDMLATEIV(_OrthoLearner):
                          categories=categories,
                          n_splits=n_splits, random_state=random_state)
 
+    @_deprecate_positional("W and Z should be passed by keyword only. In a future release "
+                           "we will disallow passing W and Z by position.", ['W', 'Z'])
     def fit(self, Y, T, Z, W=None, *, sample_weight=None, sample_var=None, groups=None, inference=None):
         """
         Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
@@ -506,6 +509,8 @@ class _BaseDMLIV(_OrthoLearner):
                          categories=categories,
                          n_splits=n_splits, random_state=random_state)
 
+    @_deprecate_positional("Z and X should be passed by keyword only. In a future release "
+                           "we will disallow passing Z and X by position.", ['X', 'Z'])
     def fit(self, Y, T, Z, X=None, *, sample_weight=None, sample_var=None, groups=None, inference=None):
         """
         Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
@@ -1049,6 +1054,8 @@ class _BaseDRIV(_OrthoLearner):
                          discrete_instrument=discrete_instrument, discrete_treatment=discrete_treatment,
                          categories=categories, n_splits=n_splits, random_state=random_state)
 
+    @_deprecate_positional("X, W, and Z should be passed by keyword only. In a future release "
+                           "we will disallow passing X, W, and Z by position.", ['X', 'W', 'Z'])
     def fit(self, Y, T, Z, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference=None):
         """
         Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
@@ -1428,7 +1435,9 @@ class LinearIntentToTreatDRIV(StatsModelsCateEstimatorMixin, IntentToTreatDRIV):
                          categories=categories)
 
     # override only so that we can update the docstring to indicate support for `StatsModelsInference`
-    def fit(self, Y, T, Z, X=None, W=None, sample_weight=None, sample_var=None, groups=None, inference='auto'):
+    @_deprecate_positional("X, W, and Z should be passed by keyword only. In a future release "
+                           "we will disallow passing X, W, and Z by position.", ['X', 'W', 'Z'])
+    def fit(self, Y, T, Z, X=None, W=None, *, sample_weight=None, sample_var=None, groups=None, inference='auto'):
         """
         Estimate the counterfactual model from data, i.e. estimates function :math:`\\theta(\\cdot)`.
 

--- a/econml/ortho_iv.py
+++ b/econml/ortho_iv.py
@@ -1470,6 +1470,6 @@ class LinearIntentToTreatDRIV(StatsModelsCateEstimatorMixin, IntentToTreatDRIV):
         -------
         self : instance
         """
-        return super().fit(Y, T, Z, X=X, W=W,
+        return super().fit(Y, T, Z=Z, X=X, W=W,
                            sample_weight=sample_weight, sample_var=sample_var, groups=groups,
                            inference=inference)

--- a/econml/tests/test_automated_ml.py
+++ b/econml/tests/test_automated_ml.py
@@ -139,7 +139,7 @@ class TestAutomatedDML(unittest.TestCase):
                                    model_t=automl_model_clf(),
                                    model_final=automl_model_sample_weight_reg(), featurizer=None,
                                    discrete_treatment=True)
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
         _ = est.effect(X)
 
     def test_param(self):
@@ -149,7 +149,7 @@ class TestAutomatedDML(unittest.TestCase):
                                  model_t=GradientBoostingClassifier(),
                                  featurizer=None,
                                  discrete_treatment=True)
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
         _ = est.effect(X)
 
     def test_forest_dml(self):
@@ -164,7 +164,7 @@ class TestAutomatedDML(unittest.TestCase):
                                  min_samples_leaf=10,
                                  min_impurity_decrease=0.001,
                                  verbose=0, min_weight_fraction_leaf=.01)
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
         _ = est.effect(X)
 
 
@@ -180,7 +180,7 @@ class TestAutomatedMetalearners(unittest.TestCase):
 
         # Test constant and heterogeneous treatment effect, single and multi output y
 
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
         _ = est.effect(X)
 
     def test_SLearner(self):
@@ -191,7 +191,7 @@ class TestAutomatedMetalearners(unittest.TestCase):
         Y, T, X, _ = ihdp_surface_B()
         est = AutomatedSLearner(overall_model=automl_model_reg())
 
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
         _ = est.effect(X)
 
         # Test heterogeneous treatment effect with multi output Y
@@ -204,5 +204,5 @@ class TestAutomatedMetalearners(unittest.TestCase):
         est = AutomatedDomainAdaptationLearner(models=automl_model_reg(),
                                                final_models=automl_model_reg())
 
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
         _ = est.effect(X)

--- a/econml/tests/test_bootstrap.py
+++ b/econml/tests/test_bootstrap.py
@@ -82,11 +82,11 @@ class TestBootstrap(unittest.TestCase):
         y = x[:, 0:1] * 0.5 + t + np.random.normal(size=(1000, 1))
 
         est = LinearDML(LinearRegression(), LinearRegression())
-        est.fit(y, t, x)
+        est.fit(y, t, X=x)
 
         bs = BootstrapEstimator(est, 50)
         # test that we can fit with the same arguments as the base estimator
-        bs.fit(y, t, x)
+        bs.fit(y, t, X=x)
 
         # test that we can get the same attribute for the bootstrap as the original, with the same shape
         self.assertEqual(np.shape(est.coef_), np.shape(bs.coef_))
@@ -196,7 +196,7 @@ class TestBootstrap(unittest.TestCase):
         y = x[:, 0:1] * 0.5 + t + np.random.normal(size=(1000, 1))
 
         est = LinearDML(LinearRegression(), LinearRegression())
-        est.fit(y, t, x, inference='bootstrap')
+        est.fit(y, t, X=x, inference='bootstrap')
 
         # test that we can get an interval for the same attribute for the bootstrap as the original,
         # with the same shape for the lower and upper bounds
@@ -239,7 +239,7 @@ class TestBootstrap(unittest.TestCase):
                                                 PolynomialFeatures(2),
                                                 PolynomialFeatures(2),
                                                 None)
-        est.fit(y, t, x, None, z, inference=opts)
+        est.fit(y, t, X=x, W=None, Z=z, inference=opts)
 
         # test that we can get an interval for the same attribute for the bootstrap as the original,
         # with the same shape for the lower and upper bounds
@@ -293,7 +293,7 @@ class TestBootstrap(unittest.TestCase):
         est = LinearIntentToTreatDRIV(model_Y_X=LinearRegression(), model_T_XZ=LogisticRegression(),
                                       flexible_model_effect=LinearRegression(), n_splits=2)
         inference = BootstrapInference(n_bootstrap_samples=20)
-        est.fit(Y, T, Z, X=X, inference=inference)
+        est.fit(Y, T, Z=Z, X=X, inference=inference)
         est.const_marginal_effect_interval(X)
 
     def test_all_kinds(self):

--- a/econml/tests/test_cate_interpreter.py
+++ b/econml/tests/test_cate_interpreter.py
@@ -29,7 +29,7 @@ class TestCateInterpreter(unittest.TestCase):
                 T = np.random.binomial(1, 0.5, size=t_shape)
                 Y = np.random.normal(size=y_shape)
                 est = LinearDML(discrete_treatment=True)
-                est.fit(Y, T, X)
+                est.fit(Y, T, X=X)
                 for intrp in [SingleTreeCateInterpreter(), SingleTreePolicyInterpreter()]:
                     with self.subTest(t_shape=t_shape, y_shape=y_shape, intrp=intrp):
                         with self.assertRaises(Exception):
@@ -50,7 +50,7 @@ class TestCateInterpreter(unittest.TestCase):
         T = np.random.binomial(1, 0.5, size=(n,))
         Y = np.random.normal(size=(n,))
         est = LinearDML(discrete_treatment=True)
-        est.fit(Y, T, X, inference=None)
+        est.fit(Y, T, X=X, inference=None)
 
         # can interpret without uncertainty
         intrp = SingleTreeCateInterpreter()
@@ -62,7 +62,7 @@ class TestCateInterpreter(unittest.TestCase):
             intrp.interpret(est, X)
 
         # can interpret with uncertainty if we refit
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
         intrp.interpret(est, X)
 
     def test_can_assign_treatment(self):
@@ -71,7 +71,7 @@ class TestCateInterpreter(unittest.TestCase):
         T = np.random.binomial(1, 0.5, size=(n,))
         Y = np.random.normal(size=(n,))
         est = LinearDML(discrete_treatment=True)
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
 
         # can interpret without uncertainty
         intrp = SingleTreePolicyInterpreter()
@@ -173,7 +173,7 @@ class TestCateInterpreter(unittest.TestCase):
                 export_kwargs.update(common_kwargs)
                 policy_intrp_kwargs.update(intrp_kwargs)
 
-                est.fit(Y, T, X, **fit_kwargs)
+                est.fit(Y, T, X=X, **fit_kwargs)
 
                 intrp = SingleTreeCateInterpreter(**cate_init_kwargs)
                 intrp.interpret(est, X2, **intrp_kwargs)

--- a/econml/tests/test_deepiv.py
+++ b/econml/tests/test_deepiv.py
@@ -194,7 +194,7 @@ class TestDeepIV(unittest.TestCase):
                                      lambda t, x: hmodel(keras.layers.concatenate([t, x])),
                                      n_samples=n1, use_upper_bound_loss=u, n_gradient_samples=n2,
                                      first_stage_options={'epochs': epochs}, second_stage_options={'epochs': epochs})
-            deepIv.fit(y, p, x, z)
+            deepIv.fit(y, p, X=x, Z=z)
 
             losses.append(np.mean(np.square(y_fresh - deepIv.predict(p_fresh, x_fresh))))
             marg_effs.append(deepIv.marginal_effect(np.array([[0.3], [0.5], [0.7]]), np.array([[0.4], [0.6], [0.2]])))
@@ -335,7 +335,7 @@ Response:{y}".format(**{'x': x.shape, 'z': z.shape,
                                      lambda t, x: hmodel(keras.layers.concatenate([t, x])),
                                      n_samples=n1, use_upper_bound_loss=u, n_gradient_samples=n2,
                                      first_stage_options={'epochs': epochs}, second_stage_options={'epochs': epochs})
-            deepIv.fit(y, t, x, z)
+            deepIv.fit(y, t, X=x, Z=z)
 
             losses.append(monte_carlo_error(lambda x, z, t: deepIv.predict(
                 t, x), datafunction, has_latent=False, debug=False))
@@ -461,7 +461,7 @@ Response:{y}".format(**{'x': x.shape, 'z': z.shape,
                                      lambda t, x: hmodel(keras.layers.concatenate([t, x])),
                                      n_samples=n1, use_upper_bound_loss=u, n_gradient_samples=n2,
                                      first_stage_options={'epochs': epochs}, second_stage_options={'epochs': epochs})
-            deepIv.fit(y, t, x, z)
+            deepIv.fit(y, t, X=x, Z=z)
 
             losses.append(monte_carlo_error(lambda x, z, t: deepIv.predict(
                 t, x), datafunction, has_latent=False, debug=False))
@@ -616,7 +616,7 @@ Response:{y}".format(**{'x': x.shape, 'z': z.shape,
                                      lambda t, x: hmodel(keras.layers.concatenate([t, x])),
                                      n_samples=n1, use_upper_bound_loss=u, n_gradient_samples=n2,
                                      first_stage_options={'epochs': 20}, second_stage_options={'epochs': 20})
-            deepIv.fit(y[:n // 2], t[:n // 2], x[:n // 2], z[:n // 2])
+            deepIv.fit(y[:n // 2], t[:n // 2], X=x[:n // 2], Z=z[:n // 2])
 
             results.append({'s': s, 'n1': n1, 'u': u, 'n2': n2,
                             'loss': np.mean(np.square(y[n // 2:] - deepIv.predict(t[n // 2:], x[n // 2:]))),

--- a/econml/tests/test_dml.py
+++ b/econml/tests/test_dml.py
@@ -157,10 +157,10 @@ class TestDML(unittest.TestCase):
 
                                             if X is None and (not fit_cate_intercept):
                                                 with pytest.raises(AttributeError):
-                                                    est.fit(Y, T, X, W, inference=inf)
+                                                    est.fit(Y, T, X=X, W=W, inference=inf)
                                                 continue
 
-                                            est.fit(Y, T, X, W, inference=inf)
+                                            est.fit(Y, T, X=X, W=W, inference=inf)
 
                                             # ensure we can pickle the fit estimator
                                             pickle.dumps(est)
@@ -393,10 +393,10 @@ class TestDML(unittest.TestCase):
                                                       is_discrete=is_discrete, est=est, inf=inf):
                                         if X is None:
                                             with pytest.raises(AttributeError):
-                                                est.fit(Y, T, X, W, inference=inf)
+                                                est.fit(Y, T, X=X, W=W, inference=inf)
                                             continue
 
-                                        est.fit(Y, T, X, W, inference=inf)
+                                        est.fit(Y, T, X=X, W=W, inference=inf)
                                         # make sure we can call the marginal_effect and effect methods
                                         const_marg_eff = est.const_marginal_effect(X)
                                         marg_eff = est.marginal_effect(T, X)
@@ -510,13 +510,13 @@ class TestDML(unittest.TestCase):
         X = np.ones((8, 1))
         est = LinearDML(n_splits=[(np.arange(4, 8), np.arange(4))], discrete_treatment=True)
         with pytest.raises(AttributeError):
-            est.fit(Y, T, X)
+            est.fit(Y, T, X=X)
         Y = np.array([2, 3, 1, 3, 2, 1, 1, 1])
         T = np.array([2, 2, 1, 2, 2, 2, 2, 2])
         X = np.ones((8, 1))
         est = LinearDML(n_splits=[(np.arange(4, 8), np.arange(4))], discrete_treatment=True)
         with pytest.raises(AttributeError):
-            est.fit(Y, T, X)
+            est.fit(Y, T, X=X)
 
     def test_bad_treatment_nonparam(self):
         """
@@ -530,14 +530,14 @@ class TestDML(unittest.TestCase):
                           model_final=WeightedLasso(),
                           discrete_treatment=True)
         with pytest.raises(AttributeError):
-            est.fit(Y, T, X)
+            est.fit(Y, T, X=X)
         T = np.ones((8, 2))
         est = NonParamDML(model_y=WeightedLasso(),
                           model_t=LinearRegression(),
                           model_final=WeightedLasso(),
                           discrete_treatment=False)
         with pytest.raises(AttributeError):
-            est.fit(Y, T, X)
+            est.fit(Y, T, X=X)
 
     def test_access_to_internal_models(self):
         """
@@ -552,7 +552,7 @@ class TestDML(unittest.TestCase):
                   featurizer=PolynomialFeatures(degree=2, include_bias=False),
                   fit_cate_intercept=True,
                   discrete_treatment=True)
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
         assert isinstance(est.original_featurizer, PolynomialFeatures)
         assert isinstance(est.featurizer, Pipeline)
         assert isinstance(est.model_cate, WeightedLasso)
@@ -568,7 +568,7 @@ class TestDML(unittest.TestCase):
                   featurizer=None,
                   fit_cate_intercept=True,
                   discrete_treatment=True)
-        est.fit(Y, T, X)
+        est.fit(Y, T, X=X)
         assert est.original_featurizer is None
         assert isinstance(est.featurizer, FunctionTransformer)
         assert isinstance(est.model_cate, WeightedLasso)
@@ -612,13 +612,13 @@ class TestDML(unittest.TestCase):
                                 random_state=12345)
                 if summarized:
                     if sample_var:
-                        est.fit(y_sum, T_sum, X_sum[:, :4], X_sum[:, 4:],
+                        est.fit(y_sum, T_sum, X=X_sum[:, :4], W=X_sum[:, 4:],
                                 sample_weight=n_sum, sample_var=var_sum)
                     else:
-                        est.fit(y_sum, T_sum, X_sum[:, :4], X_sum[:, 4:],
+                        est.fit(y_sum, T_sum, X=X_sum[:, :4], W=X_sum[:, 4:],
                                 sample_weight=n_sum)
                 else:
-                    est.fit(y, T, X[:, :4], X[:, 4:])
+                    est.fit(y, T, X=X[:, :4], W=X[:, 4:])
                 X_test = np.array(list(itertools.product([0, 1], repeat=4)))
                 point = est.effect(X_test)
                 truth = true_fn(X_test)
@@ -639,13 +639,13 @@ class TestDML(unittest.TestCase):
                                 random_state=12345)
                 if summarized:
                     if sample_var:
-                        est.fit(y_sum, T_sum, X_sum[:, :4], X_sum[:, 4:],
+                        est.fit(y_sum, T_sum, X=X_sum[:, :4], W=X_sum[:, 4:],
                                 sample_weight=n_sum, sample_var=var_sum)
                     else:
-                        est.fit(y_sum, T_sum, X_sum[:, :4], X_sum[:, 4:],
+                        est.fit(y_sum, T_sum, X=X_sum[:, :4], W=X_sum[:, 4:],
                                 sample_weight=n_sum)
                 else:
-                    est.fit(y, T, X[:, :4], X[:, 4:])
+                    est.fit(y, T, X=X[:, :4], W=X[:, 4:])
                 X_test = np.array(list(itertools.product([0, 1], repeat=4)))
                 point = est.effect(X_test)
                 truth = true_fn(X_test)
@@ -661,7 +661,7 @@ class TestDML(unittest.TestCase):
             SparseLinearDML(LinearRegression(), LinearRegression(), fit_cate_intercept=False)
         ]
         for dml in dmls:
-            dml.fit(np.array([1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
+            dml.fit(np.array([1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3]), X=np.ones((6, 1)))
             self.assertAlmostEqual(dml.coef_.reshape(())[()], 1)
             score = dml.score(np.array([1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
             self.assertAlmostEqual(score, 0)
@@ -674,7 +674,7 @@ class TestDML(unittest.TestCase):
         ]
         for dml in dmls:
             dml.fit(np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3]),
-                    np.ones((12, 1)), sample_weight=np.ones((12, )))
+                    X=np.ones((12, 1)), sample_weight=np.ones((12, )))
             self.assertAlmostEqual(dml.coef_.reshape(())[()], 1)
 
     def test_discrete_treatments(self):
@@ -693,7 +693,7 @@ class TestDML(unittest.TestCase):
             # Using an uneven number of examples from different classes,
             # and having the treatments in non-lexicographic order,
             # Should rule out some basic issues.
-            dml.fit(np.array([2, 3, 1, 3, 2, 1, 1, 1]), np.array([3, 2, 1, 2, 3, 1, 1, 1]), np.ones((8, 1)))
+            dml.fit(np.array([2, 3, 1, 3, 2, 1, 1, 1]), np.array([3, 2, 1, 2, 3, 1, 1, 1]), X=np.ones((8, 1)))
             np.testing.assert_almost_equal(
                 dml.effect(
                     np.ones((9, 1)),
@@ -708,13 +708,13 @@ class TestDML(unittest.TestCase):
         # test that we can fit with a KFold instance
         dml = LinearDML(LinearRegression(), LogisticRegression(C=1000),
                         discrete_treatment=True, n_splits=KFold())
-        dml.fit(np.array([1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
+        dml.fit(np.array([1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3]), X=np.ones((6, 1)))
         dml.score(np.array([1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
 
         # test that we can fit with a train/test iterable
         dml = LinearDML(LinearRegression(), LogisticRegression(C=1000),
                         discrete_treatment=True, n_splits=[([0, 1, 2], [3, 4, 5])])
-        dml.fit(np.array([1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
+        dml.fit(np.array([1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3]), X=np.ones((6, 1)))
         dml.score(np.array([1, 2, 3, 1, 2, 3]), np.array([1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
 
     def test_can_use_featurizer(self):
@@ -746,7 +746,7 @@ class TestDML(unittest.TestCase):
         dml = LinearDML(LinearRegression(), LogisticRegression(C=1000),
                         discrete_treatment=True)
         dml.fit(np.array([2, 3, 1, 3, 2, 1, 1, 1]), np.array(
-            [3, 2, 1, 2, 3, 1, 1, 1]), np.ones((8, 1)))
+            [3, 2, 1, 2, 3, 1, 1, 1]), X=np.ones((8, 1)))
         interval = dml.effect_interval(np.ones((9, 1)),
                                        T0=np.array([1, 1, 1, 2, 2, 2, 3, 3, 3]),
                                        T1=np.array([1, 2, 3, 1, 2, 3, 1, 2, 3]),
@@ -861,7 +861,7 @@ class TestDML(unittest.TestCase):
         # Test sparse estimator
         # --> test coef_, intercept_
         sparse_dml = SparseLinearDML(fit_cate_intercept=False)
-        sparse_dml.fit(Y, T, x, w)
+        sparse_dml.fit(Y, T, X=x, W=w)
         np.testing.assert_allclose(a, sparse_dml.coef_, atol=2e-1)
         with pytest.raises(AttributeError):
             sparse_dml.intercept_
@@ -936,7 +936,7 @@ class TestDML(unittest.TestCase):
 
         dml = SparseLinearDML(LinearRegression(fit_intercept=False), LinearRegression(
             fit_intercept=False), fit_cate_intercept=False)
-        dml.fit(y, t, x, w)
+        dml.fit(y, t, X=x, W=w)
 
         np.testing.assert_allclose(a, dml.coef_.reshape(-1), atol=1e-1)
         eff = reshape(t * np.choose(np.tile(p, 2), a), (-1,))
@@ -949,7 +949,7 @@ class TestDML(unittest.TestCase):
         W = np.random.normal(size=(100, 2))
         for n_splits in [1, 2, 3]:
             est = LinearDML(n_splits=n_splits)
-            est.fit(y, T, X, W)
+            est.fit(y, T, X=X, W=W)
             assert len(est.nuisance_scores_t) == len(est.nuisance_scores_y) == n_splits
 
     def test_categories(self):
@@ -973,7 +973,7 @@ class TestDML(unittest.TestCase):
 
             for dml in [dml1, dml2]:
                 dml.fit(np.array([2, 3, 1, 3, 2, 1, 1, 1]),
-                        np.array(['c', 'b', 'a', 'b', 'c', 'a', 'a', 'a'], dtype='object'), np.ones((8, 1)))
+                        np.array(['c', 'b', 'a', 'b', 'c', 'a', 'a', 'a'], dtype='object'), X=np.ones((8, 1)))
 
             # estimated effects should be identical when treatment is explicitly given
             np.testing.assert_almost_equal(

--- a/econml/tests/test_dml.py
+++ b/econml/tests/test_dml.py
@@ -719,8 +719,14 @@ class TestDML(unittest.TestCase):
 
     def test_can_use_featurizer(self):
         "Test that we can use a featurizer, and that fit is only called during training"
+
+        # predetermined splits ensure that all features are seen in each split
+        splits = ([0, 2, 3, 6, 8, 11, 13, 15, 16],
+                  [1, 4, 5, 7, 9, 10, 12, 14, 17])
+
         dml = LinearDML(LinearRegression(), LinearRegression(),
-                        fit_cate_intercept=False, featurizer=OneHotEncoder(sparse=False))
+                        fit_cate_intercept=False, featurizer=OneHotEncoder(sparse=False),
+                        n_splits=[splits, splits[::-1]])
 
         T = np.tile([1, 2, 3], 6)
         Y = np.array([1, 2, 3, 1, 2, 3])

--- a/econml/tests/test_drlearner.py
+++ b/econml/tests/test_drlearner.py
@@ -130,7 +130,7 @@ class TestDRLearner(unittest.TestCase):
                             for inf in infs:
                                 with self.subTest(d_w=d_w, d_x=d_x, d_y=d_y, d_t=d_t,
                                                   is_discrete=is_discrete, est=est, inf=inf):
-                                    est.fit(Y, T, X, W, inference=inf)
+                                    est.fit(Y, T, X=X, W=W, inference=inf)
 
                                     # ensure that we can serialize fit estimator
                                     pickle.dumps(est)
@@ -309,7 +309,7 @@ class TestDRLearner(unittest.TestCase):
         # and having the treatments in non-lexicographic order,
         # Should rule out some basic issues.
         dml.fit(np.array([2, 3, 1, 3, 2, 1, 1, 1]), np.array(
-            [3, 2, 1, 2, 3, 1, 1, 1]), np.ones((8, 1)))
+            [3, 2, 1, 2, 3, 1, 1, 1]), X=np.ones((8, 1)))
         np.testing.assert_almost_equal(dml.effect(np.ones((9, 1)),
                                                   T0=np.array(
                                                       [1, 1, 1, 2, 2, 2, 3, 3, 3]),
@@ -328,7 +328,7 @@ class TestDRLearner(unittest.TestCase):
                                   C=1000, solver='lbfgs', multi_class='auto'),
                               n_splits=KFold(n_splits=3))
         dml.fit(np.array([1, 2, 3, 1, 2, 3]), np.array(
-            [1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
+            [1, 2, 3, 1, 2, 3]), X=np.ones((6, 1)))
         dml.score(np.array([1, 2, 3, 1, 2, 3]), np.array(
             [1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
 
@@ -338,7 +338,7 @@ class TestDRLearner(unittest.TestCase):
                                   C=1000, solver='lbfgs', multi_class='auto'),
                               n_splits=[([0, 1, 2], [3, 4, 5])])
         dml.fit(np.array([1, 2, 3, 1, 2, 3]), np.array(
-            [1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
+            [1, 2, 3, 1, 2, 3]), X=np.ones((6, 1)))
         dml.score(np.array([1, 2, 3, 1, 2, 3]), np.array(
             [1, 2, 3, 1, 2, 3]), np.ones((6, 1)))
 
@@ -350,7 +350,7 @@ class TestDRLearner(unittest.TestCase):
         dml = LinearDRLearner(model_regression=LinearRegression(),
                               model_propensity=LogisticRegression(C=1000, solver='lbfgs', multi_class='auto'))
         dml.fit(np.array([2, 3, 1, 3, 2, 1, 1, 1]), np.array(
-            [3, 2, 1, 2, 3, 1, 1, 1]), np.ones((8, 1)))
+            [3, 2, 1, 2, 3, 1, 1, 1]), X=np.ones((8, 1)))
         interval = dml.effect_interval(np.ones((9, 1)),
                                        T0=np.array(
                                            [1, 1, 1, 1, 1, 1, 1, 1, 1]),
@@ -744,7 +744,7 @@ class TestDRLearner(unittest.TestCase):
         # Test sparse estimator
         # --> test coef_, intercept_
         sparse_dml = SparseLinearDRLearner(featurizer=FunctionTransformer())
-        sparse_dml.fit(Y, T, x, w)
+        sparse_dml.fit(Y, T, X=x, W=w)
         np.testing.assert_allclose(a, sparse_dml.coef_(T=1), atol=2e-1)
         np.testing.assert_allclose(sparse_dml.intercept_(T=1), 0, atol=2e-1)
         # --> test treatment effects
@@ -816,7 +816,7 @@ class TestDRLearner(unittest.TestCase):
         te_func = getattr(
             TestDRLearner, "_{te_type}_te".format(te_type=te_type))
         # Fit learner and get the effect
-        learner_instance.fit(Y, T, X)
+        learner_instance.fit(Y, T, X=X)
         te_hat = learner_instance.effect(TestDRLearner.X_test)
         # Get the true treatment effect
         te = np.apply_along_axis(te_func, 1, TestDRLearner.X_test)
@@ -844,7 +844,7 @@ class TestDRLearner(unittest.TestCase):
     def _test_inputs(self, learner_instance):
         X, T, Y = TestDRLearner.const_te_data
         # Check that one can pass in regular lists
-        learner_instance.fit(list(Y), list(T), list(X))
+        learner_instance.fit(list(Y), list(T), X=list(X))
         learner_instance.effect(list(TestDRLearner.X_test))
         # Check that it fails correctly if lists of different shape are passed in
         self.assertRaises(ValueError, learner_instance.fit,

--- a/econml/tests/test_metalearners.py
+++ b/econml/tests/test_metalearners.py
@@ -124,7 +124,7 @@ class TestMetalearners(unittest.TestCase):
             te = np.apply_along_axis(te_func, 1, TestMetalearners.X_test) * (T1 - T0)
             marginal_te = np.apply_along_axis(te_func, 1, TestMetalearners.X_test).reshape(-1, 1) * np.array([2, 4])
         # Fit learner and get the effect and marginal effect
-        learner_instance.fit(Y, T, X)
+        learner_instance.fit(Y, T, X=X)
         te_hat = learner_instance.effect(TestMetalearners.X_test, T0=T0, T1=T1)
         marginal_te_hat = learner_instance.marginal_effect(T1, TestMetalearners.X_test)
         # Compute treatment effect residuals (absolute)
@@ -143,7 +143,7 @@ class TestMetalearners(unittest.TestCase):
     def _test_inputs(self, learner_instance, T0, T1):
         X, T, Y = TestMetalearners.const_te_data
         # Check that one can pass in regular lists
-        learner_instance.fit(list(Y), list(T), list(X))
+        learner_instance.fit(list(Y), list(T), X=list(X))
         learner_instance.effect(list(TestMetalearners.X_test), T0=T0, T1=T1)
         # Check that it fails correctly if lists of different shape are passed in
         self.assertRaises(ValueError, learner_instance.fit, Y, T, X[:TestMetalearners.n // 2])

--- a/econml/tests/test_orf.py
+++ b/econml/tests/test_orf.py
@@ -57,7 +57,7 @@ class TestOrthoForest(unittest.TestCase):
                                              model_Y_final=WeightedLassoCVWrapper())
         # Test inputs for continuous treatments
         # --> Check that one can pass in regular lists
-        est.fit(list(Y), list(T), list(TestOrthoForest.X), list(TestOrthoForest.W))
+        est.fit(list(Y), list(T), X=list(TestOrthoForest.X), W=list(TestOrthoForest.W))
         # --> Check that it fails correctly if lists of different shape are passed in
         self.assertRaises(ValueError, est.fit, Y[:TestOrthoForest.n // 2], T[:TestOrthoForest.n // 2],
                           TestOrthoForest.X, TestOrthoForest.W)
@@ -71,13 +71,13 @@ class TestOrthoForest(unittest.TestCase):
                                              model_Y=Lasso(alpha=0.024),
                                              model_T_final=WeightedLassoCVWrapper(),
                                              model_Y_final=WeightedLassoCVWrapper())
-        est.fit(Y, T, TestOrthoForest.X, TestOrthoForest.W, inference="blb")
+        est.fit(Y, T, X=TestOrthoForest.X, W=TestOrthoForest.W, inference="blb")
         self._test_te(est, TestOrthoForest.expected_exp_te, tol=0.5)
         self._test_ci(est, TestOrthoForest.expected_exp_te, tol=1.5)
         # Test continuous treatments without controls
         T = TestOrthoForest.eta_sample(TestOrthoForest.n)
         Y = T * TE + TestOrthoForest.epsilon_sample(TestOrthoForest.n)
-        est.fit(Y, T, TestOrthoForest.X, inference="blb")
+        est.fit(Y, T, X=TestOrthoForest.X, inference="blb")
         self._test_te(est, TestOrthoForest.expected_exp_te, tol=0.5)
         self._test_ci(est, TestOrthoForest.expected_exp_te, tol=1.5)
 
@@ -99,12 +99,12 @@ class TestOrthoForest(unittest.TestCase):
                                            model_Y_final=WeightedLassoCVWrapper())
         # Test inputs for binary treatments
         # --> Check that one can pass in regular lists
-        est.fit(list(Y), list(T), list(TestOrthoForest.X), list(TestOrthoForest.W))
+        est.fit(list(Y), list(T), X=list(TestOrthoForest.X), W=list(TestOrthoForest.W))
         # --> Check that it fails correctly if lists of different shape are passed in
         self.assertRaises(ValueError, est.fit, Y[:TestOrthoForest.n // 2], T[:TestOrthoForest.n // 2],
                           TestOrthoForest.X, TestOrthoForest.W)
         # --> Check that it works when T, Y have shape (n, 1)
-        est.fit(Y.reshape(-1, 1), T.reshape(-1, 1), TestOrthoForest.X, TestOrthoForest.W)
+        est.fit(Y.reshape(-1, 1), T.reshape(-1, 1), X=TestOrthoForest.X, W=TestOrthoForest.W)
         # --> Check that it fails correctly when T has shape (n, 2)
         self.assertRaises(ValueError, est.fit, Y, np.ones((TestOrthoForest.n, 2)),
                           TestOrthoForest.X, TestOrthoForest.W)
@@ -122,7 +122,7 @@ class TestOrthoForest(unittest.TestCase):
                                            model_Y=Lasso(alpha=0.024),
                                            propensity_model_final=LogisticRegressionCV(penalty='l1', solver='saga'),
                                            model_Y_final=WeightedLassoCVWrapper())
-        est.fit(Y, T, TestOrthoForest.X, TestOrthoForest.W, inference="blb")
+        est.fit(Y, T, X=TestOrthoForest.X, W=TestOrthoForest.W, inference="blb")
         self._test_te(est, TestOrthoForest.expected_exp_te, tol=0.7, treatment_type='discrete')
         self._test_ci(est, TestOrthoForest.expected_exp_te, tol=1.5, treatment_type='discrete')
         # Test binary treatments without controls
@@ -130,7 +130,7 @@ class TestOrthoForest(unittest.TestCase):
         T_sigmoid = 1 / (1 + np.exp(-log_odds))
         T = np.array([np.random.binomial(1, p) for p in T_sigmoid])
         Y = T * TE + TestOrthoForest.epsilon_sample(TestOrthoForest.n)
-        est.fit(Y, T, TestOrthoForest.X, inference="blb")
+        est.fit(Y, T, X=TestOrthoForest.X, inference="blb")
         self._test_te(est, TestOrthoForest.expected_exp_te, tol=0.5, treatment_type='discrete')
         self._test_ci(est, TestOrthoForest.expected_exp_te, tol=1.5, treatment_type='discrete')
 
@@ -152,7 +152,7 @@ class TestOrthoForest(unittest.TestCase):
                                              model_Y=Lasso(alpha=0.024),
                                              model_T_final=WeightedLassoCVWrapper(),
                                              model_Y_final=WeightedLassoCVWrapper())
-        est.fit(Y, T, TestOrthoForest.X, TestOrthoForest.W, inference="blb")
+        est.fit(Y, T, X=TestOrthoForest.X, W=TestOrthoForest.W, inference="blb")
         expected_te = np.array([TestOrthoForest.expected_exp_te, TestOrthoForest.expected_const_te]).T
         self._test_te(est, expected_te, tol=0.5, treatment_type='multi')
         self._test_ci(est, expected_te, tol=2.0, treatment_type='multi')
@@ -175,7 +175,7 @@ class TestOrthoForest(unittest.TestCase):
         est = DiscreteTreatmentOrthoForest(n_trees=200,
                                            model_Y=DummyRegressor(strategy='mean'),
                                            propensity_model=DummyClassifier(strategy='prior'))
-        est.fit(y, T, X)
+        est.fit(y, T, X=X)
         assert est.const_marginal_effect(X[:3]).shape == (3, 2), "Const Marginal Effect dimension incorrect"
         assert est.marginal_effect(1, X[:3]).shape == (3, 2), "Marginal Effect dimension incorrect"
         assert est.effect(X[:3]).shape == (3,), "Effect dimension incorrect"

--- a/econml/tests/test_ortho_iv.py
+++ b/econml/tests/test_ortho_iv.py
@@ -293,7 +293,7 @@ class TestOrthoIV(unittest.TestCase):
         T = np.array([1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2])
         Z = np.array([1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2])
         X = np.array([1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6]).reshape(-1, 1)
-        est.fit(Y, T, Z, X=X)
+        est.fit(Y, T, Z=Z, X=X)
         assert isinstance(est.original_featurizer, PolynomialFeatures)
         assert isinstance(est.featurizer, Pipeline)
         assert isinstance(est.model_final, StatsModelsLinearRegression)
@@ -306,7 +306,7 @@ class TestOrthoIV(unittest.TestCase):
 
         est = LinearIntentToTreatDRIV(LinearRegression(), LogisticRegression(C=1000), WeightedLasso(),
                                       featurizer=None)
-        est.fit(Y, T, Z, X=X)
+        est.fit(Y, T, Z=Z, X=X)
         assert est.original_featurizer is None
         assert isinstance(est.featurizer, FunctionTransformer)
         assert isinstance(est.model_final, StatsModelsLinearRegression)
@@ -321,7 +321,7 @@ class TestOrthoIV(unittest.TestCase):
         est = LinearIntentToTreatDRIV(LinearRegression(), LogisticRegression(C=1000), WeightedLasso())
         est.fit(np.array([1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2]),
                 np.array([1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2]),
-                np.array([1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2]),
+                Z=np.array([1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2]),
                 X=np.array([1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6]).reshape(-1, 1))
         interval = est.effect_interval(np.ones((9, 1)),
                                        T0=np.array([1, 1, 1, 2, 2, 2, 1, 1, 1]),

--- a/econml/tests/test_ortho_learner.py
+++ b/econml/tests/test_ortho_learner.py
@@ -185,7 +185,7 @@ class TestOrthoLearner(unittest.TestCase):
                             n_splits=2, discrete_treatment=False, discrete_instrument=False,
                             categories='auto', random_state=None)
         # test non-array inputs
-        est.fit(list(y), list(X[:, 0]), None, X[:, 1:])
+        est.fit(list(y), list(X[:, 0]), X=None, W=X[:, 1:])
         np.testing.assert_almost_equal(est.const_marginal_effect(), 1, decimal=3)
         np.testing.assert_array_almost_equal(est.effect(), np.ones(1), decimal=3)
         np.testing.assert_array_almost_equal(est.effect(T0=0, T1=10), np.ones(1) * 10, decimal=2)
@@ -202,7 +202,7 @@ class TestOrthoLearner(unittest.TestCase):
                             n_splits=KFold(n_splits=3),
                             discrete_treatment=False, discrete_instrument=False,
                             categories='auto', random_state=None)
-        est.fit(y, X[:, 0], None, X[:, 1:])
+        est.fit(y, X[:, 0], X=None, W=X[:, 1:])
         np.testing.assert_almost_equal(est.const_marginal_effect(), 1, decimal=3)
         np.testing.assert_array_almost_equal(est.effect(), np.ones(1), decimal=3)
         np.testing.assert_array_almost_equal(est.effect(T0=0, T1=10), np.ones(1) * 10, decimal=2)
@@ -219,7 +219,7 @@ class TestOrthoLearner(unittest.TestCase):
         est = _OrthoLearner(ModelNuisance(LinearRegression(), LinearRegression()), ModelFinal(),
                             n_splits=KFold(n_splits=3), discrete_treatment=False,
                             discrete_instrument=False, categories='auto', random_state=None)
-        est.fit(y, X[:, 0], None, X[:, 1:])
+        est.fit(y, X[:, 0], X=None, W=X[:, 1:])
         np.testing.assert_almost_equal(est.const_marginal_effect(), 1, decimal=3)
         np.testing.assert_array_almost_equal(est.effect(), np.ones(1), decimal=3)
         np.testing.assert_array_almost_equal(est.effect(T0=0, T1=10), np.ones(1) * 10, decimal=2)

--- a/econml/tests/test_statsmodels.py
+++ b/econml/tests/test_statsmodels.py
@@ -810,7 +810,8 @@ class TestStatsModels(unittest.TestCase):
                             est = LinearDML(model_y=LinearRegression(),
                                             model_t=LinearRegression(),
                                             linear_first_stages=False)
-                            est.fit(y, T, X[:, :d_x], X[:, d_x:], inference=StatsModelsInference(cov_type='nonrobust'))
+                            est.fit(y, T, X=X[:, :d_x], W=X[:, d_x:],
+                                    inference=StatsModelsInference(cov_type='nonrobust'))
                             intercept = est.intercept_.reshape((p, q))
                             lower_int, upper_int = est.intercept__interval(alpha=.001)
                             lower_int = lower_int.reshape((p, q))
@@ -839,7 +840,8 @@ class TestStatsModels(unittest.TestCase):
                                             linear_first_stages=False,
                                             featurizer=PolynomialFeatures(degree=1),
                                             fit_cate_intercept=False)
-                            est.fit(y, T, X[:, :d_x], X[:, d_x:], inference=StatsModelsInference(cov_type='nonrobust'))
+                            est.fit(y, T, X=X[:, :d_x], W=X[:, d_x:],
+                                    inference=StatsModelsInference(cov_type='nonrobust'))
                             with pytest.raises(AttributeError) as e_info:
                                 intercept = est.intercept_
                             with pytest.raises(AttributeError) as e_info:

--- a/econml/tests/test_two_stage_least_squares.py
+++ b/econml/tests/test_two_stage_least_squares.py
@@ -79,7 +79,7 @@ class Test2SLS(unittest.TestCase):
                                 z_featurizer=PolynomialFeatures(),
                                 dt_featurizer=DPolynomialFeatures())
 
-                            est.fit(Y, T, X, W, Z)
+                            est.fit(Y, T, X=X, W=W, Z=Z)
 
                             eff = est.effect(X)
                             marg_eff = est.marginal_effect(T, X)
@@ -106,7 +106,7 @@ class Test2SLS(unittest.TestCase):
             z_featurizer=PolynomialFeatures(degree=2, interaction_only=False, include_bias=True),
             dt_featurizer=DPolynomialFeatures(degree=2, interaction_only=False, include_bias=True))
 
-        est.fit(Y, T, X, W, Z)
+        est.fit(Y, T, X=X, W=W, Z=Z)
 
         # pick some arbitrary X
         X_test = np.array([[0.3, 0.7],
@@ -151,7 +151,7 @@ class Test2SLS(unittest.TestCase):
         for (dt, dx, dz) in [(0, 0, 0), (1, 1, 1), (5, 5, 5), (10, 10, 10), (3, 3, 10), (10, 10, 3)]:
             np2sls = NonparametricTwoStageLeastSquares(HermiteFeatures(
                 dt), HermiteFeatures(dx), HermiteFeatures(dz), HermiteFeatures(dt, shift=1))
-            np2sls.fit(y, p, x, w, z)
+            np2sls.fit(y, p, X=x, W=w, Z=z)
             effect = np2sls.effect(x_fresh, np.zeros(shape(p_fresh)), p_fresh)
             losses.append(np.mean(np.square(p_fresh * x_fresh - effect)))
             marg_effs.append(np2sls.marginal_effect(np.array([[0.3], [0.5], [0.7]]), np.array([[0.4], [0.6], [0.2]])))

--- a/econml/two_stage_least_squares.py
+++ b/econml/two_stage_least_squares.py
@@ -7,7 +7,7 @@ import numpy as np
 from copy import deepcopy
 from sklearn import clone
 from sklearn.linear_model import LinearRegression
-from .utilities import shape, transpose, reshape, cross_product, ndim, size
+from .utilities import shape, transpose, reshape, cross_product, ndim, size, _deprecate_positional
 from .cate_estimator import BaseCateEstimator, LinearCateEstimator
 from numpy.polynomial.hermite_e import hermeval
 from sklearn.base import TransformerMixin
@@ -203,8 +203,10 @@ class NonparametricTwoStageLeastSquares(BaseCateEstimator):
         self._model_Y = LinearRegression(fit_intercept=False)
         super().__init__()
 
+    @_deprecate_positional("X, W, and Z should be passed by keyword only. In a future release "
+                           "we will disallow passing X, W, and Z by position.", ['X', 'W', 'Z'])
     @BaseCateEstimator._wrap_fit
-    def fit(self, Y, T, X, W, Z, inference=None):
+    def fit(self, Y, T, X, W, Z, *, inference=None):
         """
         Estimate the counterfactual model from data, i.e. estimates functions τ(·, ·, ·), ∂τ(·, ·).
 

--- a/monte_carlo_tests/monte_carlo_statsmodels.py
+++ b/monte_carlo_tests/monte_carlo_statsmodels.py
@@ -298,7 +298,7 @@ def run_all_mc(first_stage, folder, n_list, n_exp, hetero_coef_list, d_list,
                                                    n_splits=Splitter(),
                                                    linear_first_stages=False,
                                                    discrete_treatment=False)
-                                    lr.fit(y, X[:, -d_t:], X[:, :d_x], X[:, d_x:-d_t],
+                                    lr.fit(y, X[:, -d_t:], X=X[:, :d_x], W=X[:, d_x:-d_t],
                                            inference=StatsModelsInference(cov_type=cov_type))
                                     for alpha in alpha_list:
                                         key = ("n_{}_n_exp_{}_hetero_{}_d_{}_d_x_"

--- a/notebooks/AutomatedML/Automated Machine Learning For EconML.ipynb
+++ b/notebooks/AutomatedML/Automated Machine Learning For EconML.ipynb
@@ -354,7 +354,7 @@
     "est = LinearDML(model_y=RandomForestRegressor(),\n",
     "                model_t=RandomForestRegressor(),\n",
     "                random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_rf_regressor = est.effect(X_test)"
    ]
   },
@@ -367,7 +367,7 @@
     "est = LinearDML(model_y=grid_search_reg(),\n",
     "                model_t=grid_search_reg(),\n",
     "                random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_cv_regressor = est.effect(X_test)"
    ]
   },
@@ -391,7 +391,7 @@
     "est = AutomatedLinearDML(model_y=automl_config_reg,\n",
     "                         model_t=automl_config_reg,\n",
     "                         random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_aml_regressor = est.effect(X_test)"
    ]
   },
@@ -450,7 +450,7 @@
     "          model_final=Lasso(alpha=0.0001, fit_intercept=False),\n",
     "          featurizer=PolynomialFeatures(degree=5),\n",
     "          random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_rf_regressor_2=est.effect(X_test)"
    ]
   },
@@ -465,7 +465,7 @@
     "          model_final=Lasso(alpha=0.0001, fit_intercept=False),\n",
     "          featurizer=PolynomialFeatures(degree=5),\n",
     "          random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_cv_regressor_2 = est.effect(X_test)"
    ]
   },
@@ -496,7 +496,7 @@
     "                   model_final=Lasso(alpha=0.0001, fit_intercept=False),\n",
     "                   featurizer=PolynomialFeatures(degree=5),\n",
     "                   random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_aml_regressor_2=est.effect(X_test)"
    ]
   },
@@ -552,7 +552,7 @@
     "                min_samples_leaf=10,\n",
     "                min_impurity_decrease=0.001,\n",
     "                verbose=0, min_weight_fraction_leaf=.01)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_rf_regressor_3 = est.effect(X_test)"
    ]
   },
@@ -570,7 +570,7 @@
     "                min_samples_leaf=10,\n",
     "                min_impurity_decrease=0.001,\n",
     "                verbose=0, min_weight_fraction_leaf=.01)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pcdred_cv_regressor_3 = est.effect(X_test)"
    ]
   },
@@ -604,7 +604,7 @@
     "                         min_samples_leaf=10,\n",
     "                         min_impurity_decrease=0.001,\n",
     "                         verbose=0, min_weight_fraction_leaf=.01)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_aml_regressor_3 = est.effect(X_test)"
    ]
   },
@@ -677,7 +677,7 @@
     "          model_final=RandomForestRegressor(),\n",
     "          featurizer=PolynomialFeatures(degree=5),\n",
     "          random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_rf_regressor_4 = est.effect(X_test)"
    ]
   },
@@ -692,7 +692,7 @@
     "          model_final=grid_search_reg(),\n",
     "          featurizer=PolynomialFeatures(degree=5),\n",
     "          random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_cv_regressor_4 = est.effect(X_test)"
    ]
   },
@@ -725,7 +725,7 @@
     "                   model_final=automl_config_final,\n",
     "                   featurizer=PolynomialFeatures(degree=5),\n",
     "                   random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_aml_regressor_4 = est.effect(X_test)"
    ]
   },
@@ -790,7 +790,7 @@
     "                   model_final=automl_config_reg,\n",
     "                   featurizer=PolynomialFeatures(degree=5),\n",
     "                   random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_aml_regressor_4 = est.effect(X_test)"
    ]
   },
@@ -865,7 +865,7 @@
     "                  model_t=RandomForestRegressor(),\n",
     "                  model_final=RandomForestRegressor(),\n",
     "                  random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_rf_regressor_6 = est.effect(X_test)"
    ]
   },
@@ -879,7 +879,7 @@
     "                  model_t=grid_search_reg(),\n",
     "                  model_final=grid_search_reg(),\n",
     "                random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_cv_regressor_6 = est.effect(X_test)"
    ]
   },
@@ -913,7 +913,7 @@
     "                           model_t=automl_config_reg,\n",
     "                           model_final=automl_config_final,\n",
     "                           random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred_aml_regressor_6 = est.effect(X_test)"
    ]
   },
@@ -996,7 +996,7 @@
     "# Instantiate T learner\n",
     "T_learner_rf = TLearner(grid_search_reg())\n",
     "# Train T_learner\n",
-    "T_learner_rf.fit(Y, T, X)\n",
+    "T_learner_rf.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "T_te_rf = T_learner_rf.effect(X)"
    ]
@@ -1024,7 +1024,7 @@
     "AutomatedTLearner =  addAutomatedML(TLearner)\n",
     "T_learner_aml = AutomatedTLearner(models = automl_config_reg)\n",
     "# Train T_learner\n",
-    "T_learner_aml.fit(Y, T, X)\n",
+    "T_learner_aml.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "T_te_aml = T_learner_aml.effect(X)"
    ]
@@ -1074,7 +1074,7 @@
     "overall_model = grid_search_reg()\n",
     "S_learner_rf = SLearner(overall_model)\n",
     "# Train S_learner\n",
-    "S_learner_rf.fit(Y, T, X)\n",
+    "S_learner_rf.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "S_te_rf = S_learner_rf.effect(X)"
    ]
@@ -1100,7 +1100,7 @@
     "AutomatedSLearner =  addAutomatedML(SLearner)\n",
     "S_learner_aml = AutomatedSLearner(overall_model= automl_config_reg)\n",
     "# Train S_learner\n",
-    "S_learner_aml.fit(Y, T, X)\n",
+    "S_learner_aml.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "S_te_aml = S_learner_aml.effect(X)"
    ]
@@ -1150,7 +1150,7 @@
     "final_models = grid_search_reg()\n",
     "DA_learner_rf = DomainAdaptationLearner(models=models, final_models=final_models)\n",
     "# Train DA_learner\n",
-    "DA_learner_rf.fit(Y, T, X)\n",
+    "DA_learner_rf.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "DA_rf_te = DA_learner_rf.effect(X)"
    ]
@@ -1181,7 +1181,7 @@
     "AutomatedDomainAdaptationLearner =  addAutomatedML(DomainAdaptationLearner)\n",
     "DA_learner_aml = AutomatedDomainAdaptationLearner(models=models, final_models=final_models)\n",
     "# Train X_learner\n",
-    "DA_learner_aml.fit(Y, T, X)\n",
+    "DA_learner_aml.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "DA_te_aml = DA_learner_aml.effect(X)"
    ]
@@ -1257,7 +1257,7 @@
     "                           model_t=automl_config_clf,\n",
     "                           model_final=automl_config_reg, featurizer=None,\n",
     "                           discrete_treatment=True)\n",
-    "est.fit(Y, T, X)\n",
+    "est.fit(Y, T, X=X)\n",
     "_ = est.effect(X)"
    ]
   }

--- a/notebooks/CustomerScenarios/Case Study - Customer Segmentation at An Online Media Company.ipynb
+++ b/notebooks/CustomerScenarios/Case Study - Customer Segmentation at An Online Media Company.ipynb
@@ -385,7 +385,7 @@
     "    model_t=GradientBoostingRegressor(),\n",
     "    featurizer=PolynomialFeatures(degree=2, include_bias=False),\n",
     ")\n",
-    "est.fit(log_Y, log_T, X, W, inference=\"statsmodels\")\n",
+    "est.fit(log_Y, log_T, X=X, W=W, inference=\"statsmodels\")\n",
     "# Get treatment effect and its confidence interval\n",
     "te_pred = est.effect(X_test)\n",
     "te_pred_interval = est.effect_interval(X_test)"
@@ -534,7 +534,7 @@
     "est = ForestDML(\n",
     "    model_y=GradientBoostingRegressor(), model_t=GradientBoostingRegressor()\n",
     ")\n",
-    "est.fit(log_Y, log_T, X, W, inference=\"blb\")\n",
+    "est.fit(log_Y, log_T, X=X, W=W, inference=\"blb\")\n",
     "# Get treatment effect and its confidence interval\n",
     "te_pred = est.effect(X_test)\n",
     "te_pred_interval = est.effect_interval(X_test)"

--- a/notebooks/CustomerScenarios/Case Study - Recommendation AB Testing at An Online Travel Company.ipynb
+++ b/notebooks/CustomerScenarios/Case Study - Recommendation AB Testing at An Online Travel Company.ipynb
@@ -435,7 +435,7 @@
     "    flexible_model_effect = flexible_model_effect,\n",
     "    featurizer = PolynomialFeatures(degree=1, include_bias=False)\n",
     ")\n",
-    "model.fit(Y.values, T, Z, X_data.values, inference=\"statsmodels\")"
+    "model.fit(Y.values, T, Z=Z, X=X_data.values, inference=\"statsmodels\")"
    ]
   },
   {

--- a/notebooks/Double Machine Learning Examples.ipynb
+++ b/notebooks/Double Machine Learning Examples.ipynb
@@ -180,7 +180,7 @@
     "est = LinearDML(model_y=RandomForestRegressor(),\n",
     "                model_t=RandomForestRegressor(),\n",
     "                random_state=123)\n",
-    "est.fit(Y_train, T_train, X_train, W_train)\n",
+    "est.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred = est.effect(X_test)"
    ]
   },
@@ -201,7 +201,7 @@
     "                       model_t=RandomForestRegressor(),\n",
     "                       featurizer=PolynomialFeatures(degree=3),\n",
     "                       random_state=123)\n",
-    "est1.fit(Y_train, T_train, X_train, W_train)\n",
+    "est1.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred1=est1.effect(X_test)"
    ]
   },
@@ -223,7 +223,7 @@
     "           model_final=Lasso(alpha=0.1, fit_intercept=False),\n",
     "           featurizer=PolynomialFeatures(degree=10),\n",
     "           random_state=123)\n",
-    "est2.fit(Y_train, T_train, X_train, W_train)\n",
+    "est2.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred2=est2.effect(X_test)"
    ]
   },
@@ -252,7 +252,7 @@
     "                 min_samples_leaf=10,\n",
     "                 min_impurity_decrease=0.001,\n",
     "                 verbose=0, min_weight_fraction_leaf=.01)\n",
-    "est3.fit(Y_train, T_train, X_train, W_train)\n",
+    "est3.fit(Y_train, T_train, X=X_train, W=W_train)\n",
     "te_pred3 = est3.effect(X_test)"
    ]
   },
@@ -502,7 +502,7 @@
     "                discrete_treatment=True,\n",
     "                linear_first_stages=False,\n",
     "                n_splits=6)\n",
-    "est.fit(Y, T, X, W)\n",
+    "est.fit(Y, T, X=X, W=W)\n",
     "te_pred = est.effect(X_test)\n",
     "lb, ub = est.effect_interval(X_test, alpha=0.01)"
    ]
@@ -519,7 +519,7 @@
     "                       featurizer=PolynomialFeatures(degree=2),\n",
     "                       linear_first_stages=False,\n",
     "                       n_splits=6)\n",
-    "est2.fit(Y, T, X, W)\n",
+    "est2.fit(Y, T, X=X, W=W)\n",
     "te_pred2 = est2.effect(X_test)\n",
     "lb2, ub2 = est2.effect_interval(X_test, alpha=0.01)"
    ]
@@ -539,7 +539,7 @@
     "                 min_impurity_decrease=0.001,\n",
     "                 verbose=0, min_weight_fraction_leaf=.01,\n",
     "                 n_crossfit_splits=6)\n",
-    "est3.fit(Y, T, X, W)\n",
+    "est3.fit(Y, T, X=X, W=W)\n",
     "te_pred3 = est3.effect(X_test)\n",
     "lb3, ub3 = est3.effect_interval(X_test, alpha=0.01)"
    ]
@@ -1167,7 +1167,7 @@
    ],
    "source": [
     "T = T.reshape(-1,1)\n",
-    "est.fit(Y, np.concatenate((T, T**2), axis=1), X, W)"
+    "est.fit(Y, np.concatenate((T, T**2), axis=1), X=X, W=W)"
    ]
   },
   {
@@ -1504,7 +1504,7 @@
    "outputs": [],
    "source": [
     "est = LinearDML(model_y=RandomForestRegressor(),model_t=RandomForestRegressor())\n",
-    "est.fit(Y, T, X, W)\n",
+    "est.fit(Y, T, X=X, W=W)\n",
     "te_pred=est.effect(X_test)"
    ]
   },
@@ -1559,7 +1559,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "est.fit(Y, T, X, W)\n",
+    "est.fit(Y, T, X=X, W=W)\n",
     "te_pred=est.effect(X_test)\n",
     "te_pred_interval = est.const_marginal_effect_interval(X_test, alpha=0.02)"
    ]
@@ -1695,7 +1695,7 @@
     "                model_t=MultiTaskElasticNetCV(cv=3),\n",
     "                featurizer=PolynomialFeatures(1),\n",
     "                linear_first_stages=True)\n",
-    "est.fit(Y, T, X, W)\n",
+    "est.fit(Y, T, X=X, W=W)\n",
     "te_pred = est.const_marginal_effect(X_test)"
    ]
   },
@@ -1761,7 +1761,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "est.fit(Y, T, X, W)\n",
+    "est.fit(Y, T, X=X, W=W)\n",
     "te_pred = est.const_marginal_effect(X_test)\n",
     "te_pred_interval = est.const_marginal_effect_interval(X_test, alpha=0.02)"
    ]

--- a/notebooks/ForestLearners Basic Example.ipynb
+++ b/notebooks/ForestLearners Basic Example.ipynb
@@ -214,7 +214,7 @@
     "                min_samples_leaf=10,\n",
     "                verbose=0,\n",
     "                min_weight_fraction_leaf=.005)\n",
-    "est.fit(Y, T, X)\n"
+    "est.fit(Y, T, X=X)\n"
    ]
   },
   {
@@ -240,7 +240,7 @@
     "                   n_splits=3,\n",
     "                   discrete_treatment=True,\n",
     "                   model_final=final_stage())\n",
-    "est2.fit(Y, T, X)"
+    "est2.fit(Y, T, X=X)"
    ]
   },
   {
@@ -477,7 +477,7 @@
     "                      min_samples_leaf=10,\n",
     "                      verbose=0,\n",
     "                      min_weight_fraction_leaf=.005)\n",
-    "est.fit(Y, T, X)"
+    "est.fit(Y, T, X=X)"
    ]
   },
   {
@@ -502,7 +502,7 @@
     "                 model_propensity=first_stage_clf(),\n",
     "                 model_final=final_stage(),\n",
     "                 n_splits=3)\n",
-    "est2.fit(Y, T, X)"
+    "est2.fit(Y, T, X=X)"
    ]
   },
   {
@@ -757,7 +757,7 @@
     "                                    model_Y_final=WeightedLassoCV(cv=3),\n",
     "                                    propensity_model_final=LogisticRegressionCV(cv=3),\n",
     "                                    n_trees=1000, min_leaf_size=10)\n",
-    "est3.fit(Y, T, X)"
+    "est3.fit(Y, T, X=X)"
    ]
   },
   {

--- a/notebooks/Metalearners Examples.ipynb
+++ b/notebooks/Metalearners Examples.ipynb
@@ -186,7 +186,7 @@
     "models = GradientBoostingRegressor(n_estimators=100, max_depth=6, min_samples_leaf=int(n/100))\n",
     "T_learner = TLearner(models)\n",
     "# Train T_learner\n",
-    "T_learner.fit(Y, T, X)\n",
+    "T_learner.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "T_te = T_learner.effect(X_test)"
    ]
@@ -201,7 +201,7 @@
     "overall_model = GradientBoostingRegressor(n_estimators=100, max_depth=6, min_samples_leaf=int(n/100))\n",
     "S_learner = SLearner(overall_model)\n",
     "# Train S_learner\n",
-    "S_learner.fit(Y, T, X)\n",
+    "S_learner.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "S_te = S_learner.effect(X_test)"
    ]
@@ -218,7 +218,7 @@
     "                                                  min_samples_leaf=int(n/100))\n",
     "X_learner = XLearner(models=models, propensity_model=propensity_model)\n",
     "# Train X_learner\n",
-    "X_learner.fit(Y, T, X)\n",
+    "X_learner.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "X_te = X_learner.effect(X_test)"
    ]
@@ -237,7 +237,7 @@
     "DA_learner = DomainAdaptationLearner(models=models, final_models=final_models, \n",
     "                  propensity_model=propensity_model)\n",
     "# Train DA_learner\n",
-    "DA_learner.fit(Y, T, X)\n",
+    "DA_learner.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "DA_te = DA_learner.effect(X_test)"
    ]
@@ -258,7 +258,7 @@
     "DR_learner = DRLearner(model_regression=outcome_model, model_propensity=propensity_model,\n",
     "                       model_final=pseudo_treatment_model, n_splits=5)\n",
     "# Train DR_learner\n",
-    "DR_learner.fit(Y, T, X)\n",
+    "DR_learner.fit(Y, T, X=X)\n",
     "# Estimate treatment effects on test data\n",
     "DR_te = DR_learner.effect(X_test)"
    ]
@@ -393,7 +393,7 @@
    "outputs": [],
    "source": [
     "# T-learner\n",
-    "T_learner.fit(Y, T, X)\n",
+    "T_learner.fit(Y, T, X=X)\n",
     "T_te = T_learner.effect(X)"
    ]
   },
@@ -404,7 +404,7 @@
    "outputs": [],
    "source": [
     "# S-learner\n",
-    "S_learner.fit(Y, T, X)\n",
+    "S_learner.fit(Y, T, X=X)\n",
     "S_te = S_learner.effect(X)"
    ]
   },
@@ -415,7 +415,7 @@
    "outputs": [],
    "source": [
     "# X-learner\n",
-    "X_learner.fit(Y, T, X)\n",
+    "X_learner.fit(Y, T, X=X)\n",
     "X_te = X_learner.effect(X)"
    ]
   },
@@ -426,7 +426,7 @@
    "outputs": [],
    "source": [
     "# Domain adaptation learner\n",
-    "DA_learner.fit(Y, T, X)\n",
+    "DA_learner.fit(Y, T, X=X)\n",
     "DA_te = DA_learner.effect(X)"
    ]
   },
@@ -437,7 +437,7 @@
    "outputs": [],
    "source": [
     "# Doubly robust learner\n",
-    "DR_learner.fit(Y, T, X)\n",
+    "DR_learner.fit(Y, T, X=X)\n",
     "DR_te = DR_learner.effect(X)"
    ]
   },

--- a/notebooks/Orthogonal Random Forest Examples.ipynb
+++ b/notebooks/Orthogonal Random Forest Examples.ipynb
@@ -210,7 +210,7 @@
     }
    ],
    "source": [
-    "est.fit(Y, T, X, W, inference=\"blb\")"
+    "est.fit(Y, T, X=X, W=W, inference=\"blb\")"
    ]
   },
   {
@@ -408,7 +408,7 @@
     }
    ],
    "source": [
-    "est.fit(Y, T, X, W, inference=\"blb\")"
+    "est.fit(Y, T, X=X, W=W, inference=\"blb\")"
    ]
   },
   {
@@ -614,7 +614,7 @@
     }
    ],
    "source": [
-    "est.fit(Y, T, X, W, inference=\"blb\")"
+    "est.fit(Y, T, X=X, W=W, inference=\"blb\")"
    ]
   },
   {
@@ -1002,7 +1002,7 @@
     }
    ],
    "source": [
-    "est.fit(Y, T, X, W, inference=\"blb\")"
+    "est.fit(Y, T, X=X, W=W, inference=\"blb\")"
    ]
   },
   {


### PR DESCRIPTION
This change deprecates passing arguments to fit (other than Y and T) by position, rather than by keyword.  So, for example `est.fit(Y, T, X)` will warn, while `est.fit(Y, T, X=None)` will not.