### PR TITLE
Move StatsModelsLinearRegression

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
   dependsOn: 'EvalChanges'
   condition: eq(dependencies.EvalChanges.outputs['output.buildDocs'], 'True')
   pool: 
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   variables:
     python.version: '3.6'
   steps:
@@ -83,7 +83,7 @@ jobs:
   variables:
     python.version: '3.8'
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
   - template: azure-pipelines-steps.yml
     parameters:
@@ -109,7 +109,7 @@ jobs:
 #   variables:
 #     python.version: '3.6'
 #   pool:
-#     vmImage: 'ubuntu-16.04'
+#     vmImage: 'ubuntu-18.04'
 #   steps:
 #   - template: azure-pipelines-steps.yml
 #     parameters:
@@ -159,31 +159,31 @@ jobs:
   strategy:
     matrix:
       Linux, Python 3.6:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-18.04'
         python.version: '3.6'
       macOS, Python 3.6:
         imageName: 'macOS-10.15'
         python.version: '3.6'
       Windows, Python 3.6:
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
         python.version: '3.6'
       Linux, Python 3.7:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-18.04'
         python.version: '3.7'
       macOS, Python 3.7:
         imageName: 'macOS-10.15'
         python.version: '3.7'
       Windows, Python 3.7:
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
         python.version: '3.7'
       Linux, Python 3.8:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-18.04'
         python.version: '3.8'
       macOS, Python 3.8:
         imageName: 'macOS-10.15'
         python.version: '3.8'
       Windows, Python 3.8:
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
         python.version: '3.8'
 
   pool:

--- a/econml/_ortho_learner.py
+++ b/econml/_ortho_learner.py
@@ -24,23 +24,21 @@ Chernozhukov et al. (2017). Double/debiased machine learning for treatment and s
 
 """
 
-import numpy as np
 import copy
 from warnings import warn
-from .utilities import (shape, reshape, ndim, hstack, cross_product, transpose, inverse_onehot,
-                        broadcast_unit_treatments, reshape_treatmentwise_effects, filter_none_kwargs,
-                        _deprecate_positional, StatsModelsLinearRegression, _EncoderWrapper)
+
+import numpy as np
+from sklearn.base import clone
 from sklearn.model_selection import KFold, StratifiedKFold, check_cv
-from sklearn.linear_model import LinearRegression, LassoCV
-from sklearn.preprocessing import (PolynomialFeatures, LabelEncoder, OneHotEncoder,
-                                   FunctionTransformer)
-from sklearn.base import clone, TransformerMixin
-from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import (FunctionTransformer, LabelEncoder,
+                                   OneHotEncoder)
 from sklearn.utils import check_random_state
+
 from .cate_estimator import (BaseCateEstimator, LinearCateEstimator,
-                             TreatmentExpansionMixin, StatsModelsCateEstimatorMixin)
-from .inference import StatsModelsInference
-from .utilities import check_input_arrays
+                             TreatmentExpansionMixin)
+from .utilities import (_deprecate_positional, _EncoderWrapper, check_input_arrays,
+                        cross_product, filter_none_kwargs,
+                        inverse_onehot, ndim, reshape, shape, transpose)
 
 
 def _crossfit(model, folds, *args, **kwargs):

--- a/econml/cate_estimator.py
+++ b/econml/cate_estimator.py
@@ -591,7 +591,7 @@ class LinearModelFinalCateEstimatorMixin(BaseCateEstimator):
         """
         pass
 
-    def summary(self, alpha=0.1, value=0, decimals=3, feat_name=None):
+    def summary(self, alpha=0.1, value=0, decimals=3, feat_name=None, treatment_name=None, output_name=None):
         """ The summary of coefficient and intercept in the linear model of the constant marginal treatment
         effect.
 
@@ -606,6 +606,10 @@ class LinearModelFinalCateEstimatorMixin(BaseCateEstimator):
             Number of decimal places to round each column to.
         feat_name: optional list of strings or None (default is None)
             The input of the feature names
+        treatment_name: optional list of strings or None (default is None)
+            The names of the treatments
+        output_name: optional list of strings or None (default is None)
+            The names of the outputs
 
         Returns
         -------
@@ -626,7 +630,10 @@ class LinearModelFinalCateEstimatorMixin(BaseCateEstimator):
         d_y = self._d_y[0] if self._d_y else 1
         try:
             coef_table = self.coef__inference().summary_frame(alpha=alpha,
-                                                              value=value, decimals=decimals, feat_name=feat_name)
+                                                              value=value, decimals=decimals,
+                                                              feat_name=feat_name,
+                                                              treatment_name=treatment_name,
+                                                              output_name=output_name)
             coef_array = coef_table.values
             coef_headers = [i + '\n' +
                             j for (i, j) in coef_table.columns] if d_t > 1 else coef_table.columns.tolist()
@@ -637,7 +644,10 @@ class LinearModelFinalCateEstimatorMixin(BaseCateEstimator):
             print("Coefficient Results: ", str(e))
         try:
             intercept_table = self.intercept__inference().summary_frame(alpha=alpha,
-                                                                        value=value, decimals=decimals, feat_name=None)
+                                                                        value=value, decimals=decimals,
+                                                                        feat_name=None,
+                                                                        treatment_name=treatment_name,
+                                                                        output_name=output_name)
             intercept_array = intercept_table.values
             intercept_headers = [i + '\n' + j for (i, j)
                                  in intercept_table.columns] if d_t > 1 else intercept_table.columns.tolist()
@@ -824,7 +834,7 @@ class LinearModelFinalCateEstimatorDiscreteMixin(BaseCateEstimator):
         """
         pass
 
-    def summary(self, T, *, alpha=0.1, value=0, decimals=3, feat_name=None):
+    def summary(self, T, *, alpha=0.1, value=0, decimals=3, feat_name=None, treatment_name=None, output_name=None):
         """ The summary of coefficient and intercept in the linear model of the constant marginal treatment
         effect associated with treatment T.
 
@@ -839,6 +849,10 @@ class LinearModelFinalCateEstimatorDiscreteMixin(BaseCateEstimator):
             Number of decimal places to round each column to.
         feat_name: optional list of strings or None (default is None)
             The input of the feature names
+        treatment_name: optional list of strings or None (default is None)
+            The names of the treatments
+        output_name: optional list of strings or None (default is None)
+            The names of the outputs
 
         Returns
         -------
@@ -858,7 +872,9 @@ class LinearModelFinalCateEstimatorDiscreteMixin(BaseCateEstimator):
                             "Intercept Results table portrays the $cate\\_intercept_{ij}$ parameter.</sub>"])
         try:
             coef_table = self.coef__inference(T).summary_frame(
-                alpha=alpha, value=value, decimals=decimals, feat_name=feat_name)
+                alpha=alpha, value=value, decimals=decimals, feat_name=feat_name,
+                treatment_name=treatment_name,
+                output_name=output_name)
             coef_array = coef_table.values
             coef_headers = coef_table.columns.tolist()
             coef_stubs = coef_table.index.tolist()
@@ -868,7 +884,9 @@ class LinearModelFinalCateEstimatorDiscreteMixin(BaseCateEstimator):
             print("Coefficient Results: ", e)
         try:
             intercept_table = self.intercept__inference(T).summary_frame(
-                alpha=alpha, value=value, decimals=decimals, feat_name=None)
+                alpha=alpha, value=value, decimals=decimals, feat_name=None,
+                treatment_name=treatment_name,
+                output_name=output_name)
             intercept_array = intercept_table.values
             intercept_headers = intercept_table.columns.tolist()
             intercept_stubs = intercept_table.index.tolist()

--- a/econml/dml.py
+++ b/econml/dml.py
@@ -33,29 +33,34 @@ References
 
 """
 
-import numpy as np
-import copy
+
 from warnings import warn
-from .utilities import (shape, reshape, ndim, hstack, cross_product, transpose, inverse_onehot,
-                        broadcast_unit_treatments, reshape_treatmentwise_effects, add_intercept,
-                        StatsModelsLinearRegression, LassoCVWrapper, check_high_dimensional, check_input_arrays,
-                        fit_with_groups, deprecated, _deprecate_positional)
-from econml.sklearn_extensions.linear_model import MultiOutputDebiasedLasso, WeightedLassoCVWrapper
-from econml.sklearn_extensions.ensemble import SubsampledHonestForest
+
+import numpy as np
+from sklearn.base import TransformerMixin, clone
+from sklearn.linear_model import (ElasticNetCV, LassoCV, LogisticRegressionCV)
 from sklearn.model_selection import KFold, StratifiedKFold, check_cv
-from sklearn.linear_model import LinearRegression, LassoCV, LogisticRegressionCV, ElasticNetCV
-from sklearn.preprocessing import (PolynomialFeatures, LabelEncoder, OneHotEncoder,
-                                   FunctionTransformer)
-from sklearn.base import clone, TransformerMixin
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import (FunctionTransformer, LabelEncoder,
+                                   OneHotEncoder)
 from sklearn.utils import check_random_state
-from .cate_estimator import (BaseCateEstimator, LinearCateEstimator,
-                             TreatmentExpansionMixin, StatsModelsCateEstimatorMixin,
-                             LinearModelFinalCateEstimatorMixin, DebiasedLassoCateEstimatorMixin,
-                             ForestModelFinalCateEstimatorMixin)
-from .inference import StatsModelsInference, GenericSingleTreatmentModelFinalInference
+
 from ._rlearner import _RLearner
+from .cate_estimator import (DebiasedLassoCateEstimatorMixin,
+                             ForestModelFinalCateEstimatorMixin,
+                             LinearModelFinalCateEstimatorMixin,
+                             StatsModelsCateEstimatorMixin)
+from .inference import StatsModelsInference
+from .sklearn_extensions.ensemble import SubsampledHonestForest
+from .sklearn_extensions.linear_model import (MultiOutputDebiasedLasso,
+                                              StatsModelsLinearRegression,
+                                              WeightedLassoCVWrapper)
 from .sklearn_extensions.model_selection import WeightedStratifiedKFold
+from .utilities import (_deprecate_positional, add_intercept,
+                        broadcast_unit_treatments, check_high_dimensional,
+                        check_input_arrays, cross_product, deprecated,
+                        fit_with_groups, hstack, inverse_onehot, ndim, reshape,
+                        reshape_treatmentwise_effects, shape, transpose)
 
 
 class _FirstStageWrapper:

--- a/econml/drlearner.py
+++ b/econml/drlearner.py
@@ -27,19 +27,24 @@ Tsiatis AA (2006).
 
 """
 
-import numpy as np
 from warnings import warn
 
+import numpy as np
 from sklearn.base import clone
-from sklearn.linear_model import LogisticRegressionCV, LinearRegression, LassoCV
-from econml.utilities import (inverse_onehot, check_high_dimensional, _deprecate_positional,
-                              StatsModelsLinearRegression, check_input_arrays, fit_with_groups, filter_none_kwargs)
-from econml.sklearn_extensions.linear_model import WeightedLassoCVWrapper, DebiasedLasso
-from econml.sklearn_extensions.ensemble import SubsampledHonestForest
-from econml._ortho_learner import _OrthoLearner
-from econml.cate_estimator import StatsModelsCateEstimatorDiscreteMixin, DebiasedLassoCateEstimatorDiscreteMixin,\
-    ForestModelFinalCateEstimatorDiscreteMixin
-from econml.inference import GenericModelFinalInferenceDiscrete
+from sklearn.linear_model import (LassoCV, LinearRegression,
+                                  LogisticRegressionCV)
+
+from ._ortho_learner import _OrthoLearner
+from .cate_estimator import (DebiasedLassoCateEstimatorDiscreteMixin,
+                             ForestModelFinalCateEstimatorDiscreteMixin,
+                             StatsModelsCateEstimatorDiscreteMixin)
+from .inference import GenericModelFinalInferenceDiscrete
+from .sklearn_extensions.ensemble import SubsampledHonestForest
+from .sklearn_extensions.linear_model import (
+    DebiasedLasso, StatsModelsLinearRegression, WeightedLassoCVWrapper)
+from .utilities import (_deprecate_positional, check_high_dimensional,
+                        check_input_arrays, filter_none_kwargs,
+                        fit_with_groups, inverse_onehot)
 
 
 class _ModelNuisance:

--- a/econml/inference.py
+++ b/econml/inference.py
@@ -2,18 +2,21 @@
 # Licensed under the MIT License.
 
 import abc
-import numpy as np
-import scipy
-from scipy.stats import norm
-import pandas as pd
 from collections import OrderedDict
-from statsmodels.iolib.table import SimpleTable
-from .bootstrap import BootstrapEstimator
-from .utilities import (cross_product, broadcast_unit_treatments, reshape_treatmentwise_effects,
-                        ndim, shape, inverse_onehot, parse_final_model_params, _safe_norm_ppf, Summary,
-                        StatsModelsLinearRegression)
 from warnings import warn
 
+import numpy as np
+import pandas as pd
+import scipy
+from scipy.stats import norm
+from statsmodels.iolib.table import SimpleTable
+
+from .bootstrap import BootstrapEstimator
+from .sklearn_extensions.linear_model import StatsModelsLinearRegression
+from .utilities import (Summary, _safe_norm_ppf, broadcast_unit_treatments,
+                        cross_product, inverse_onehot, ndim,
+                        parse_final_model_params,
+                        reshape_treatmentwise_effects, shape)
 
 """Options for performing inference in estimators."""
 

--- a/econml/ortho_iv.py
+++ b/econml/ortho_iv.py
@@ -16,15 +16,16 @@ https://arxiv.org/abs/1905.10176
 import numpy as np
 from sklearn.base import clone
 from sklearn.linear_model import LinearRegression
-from sklearn.preprocessing import FunctionTransformer
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import FunctionTransformer
 
 from ._ortho_learner import _OrthoLearner
-from .dml import _FinalWrapper
-from .utilities import (hstack, StatsModelsLinearRegression, inverse_onehot,
-                        add_intercept, fit_with_groups, _deprecate_positional)
-from .inference import StatsModelsInference
 from .cate_estimator import StatsModelsCateEstimatorMixin
+from .dml import _FinalWrapper
+from .inference import StatsModelsInference
+from .sklearn_extensions.linear_model import StatsModelsLinearRegression
+from .utilities import (_deprecate_positional, add_intercept, fit_with_groups,
+                        hstack, inverse_onehot)
 
 
 # A cut-down version of the DML first stage wrapper, since we don't need to support linear first stages

--- a/econml/tests/test_dml.py
+++ b/econml/tests/test_dml.py
@@ -11,10 +11,10 @@ from sklearn.model_selection import KFold, GroupKFold
 from econml.dml import DML, LinearDML, SparseLinearDML, KernelDML
 from econml.dml import NonParamDML, ForestDML
 import numpy as np
-from econml.utilities import shape, hstack, vstack, reshape, cross_product, StatsModelsLinearRegression
+from econml.utilities import shape, hstack, vstack, reshape, cross_product
 from econml.inference import BootstrapInference
 from contextlib import ExitStack
-from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor, GradientBoostingClassifier
+from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifier
 import itertools
 from econml.sklearn_extensions.linear_model import WeightedLasso, StatsModelsRLM
 from econml.tests.test_statsmodels import _summarize

--- a/econml/tests/test_dml.py
+++ b/econml/tests/test_dml.py
@@ -121,7 +121,7 @@ class TestDML(unittest.TestCase):
                                           featurizer=featurizer,
                                           fit_cate_intercept=fit_cate_intercept,
                                           discrete_treatment=is_discrete),
-                                      False,
+                                      True,
                                       ['auto']),
                                      (LinearDML(model_y=Lasso(),
                                                 model_t='auto',

--- a/econml/tests/test_drlearner.py
+++ b/econml/tests/test_drlearner.py
@@ -19,7 +19,7 @@ from econml.inference import BootstrapInference, StatsModelsInferenceDiscrete
 from contextlib import ExitStack
 from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor, RandomForestRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
-from econml.utilities import StatsModelsLinearRegression
+from econml.sklearn_extensions.linear_model import StatsModelsLinearRegression
 import scipy.special
 import econml.tests.utilities  # bugfix for assertWarns
 
@@ -390,9 +390,6 @@ class TestDRLearner(unittest.TestCase):
         assert (lo < hi).any()
 
     def test_drlearner_all_attributes(self):
-        from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor, RandomForestRegressor
-        from sklearn.linear_model import LinearRegression, LogisticRegression
-        from econml.utilities import StatsModelsLinearRegression
         import scipy.special
         np.random.seed(123)
         controls = np.random.uniform(-1, 1, size=(5000, 3))

--- a/econml/tests/test_ortho_iv.py
+++ b/econml/tests/test_ortho_iv.py
@@ -11,12 +11,12 @@ from sklearn.model_selection import KFold
 from econml.ortho_iv import (DMLATEIV, ProjectedDMLATEIV, DMLIV, NonParamDMLIV,
                              IntentToTreatDRIV, LinearIntentToTreatDRIV)
 import numpy as np
-from econml.utilities import shape, hstack, vstack, reshape, cross_product, StatsModelsLinearRegression
+from econml.utilities import shape, hstack, vstack, reshape, cross_product
 from econml.inference import BootstrapInference
 from contextlib import ExitStack
 from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor, GradientBoostingClassifier
 import itertools
-from econml.sklearn_extensions.linear_model import WeightedLasso
+from econml.sklearn_extensions.linear_model import WeightedLasso, StatsModelsLinearRegression
 from econml.tests.test_statsmodels import _summarize
 import econml.tests.utilities  # bugfix for assertWarns
 

--- a/econml/tests/test_statsmodels.py
+++ b/econml/tests/test_statsmodels.py
@@ -15,7 +15,7 @@ from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
 from sklearn.model_selection import KFold, StratifiedKFold
 import scipy.special
 import time
-from econml.utilities import StatsModelsLinearRegression as OLS
+from econml.sklearn_extensions.linear_model import StatsModelsLinearRegression as OLS
 import unittest
 import joblib
 from sklearn.preprocessing import PolynomialFeatures

--- a/econml/utilities.py
+++ b/econml/utilities.py
@@ -14,7 +14,6 @@ from sklearn.base import TransformerMixin, BaseEstimator
 from sklearn.linear_model import LassoCV, MultiTaskLassoCV, Lasso, MultiTaskLasso
 from functools import reduce, wraps
 from sklearn.utils import check_array, check_X_y
-from statsmodels.tools.tools import add_constant
 import warnings
 from warnings import warn
 from sklearn.model_selection import KFold, StratifiedKFold, GroupKFold
@@ -988,379 +987,6 @@ def _safe_norm_ppf(q, loc=0, scale=1):
     return prelim
 
 
-class StatsModelsLinearRegression(BaseEstimator):
-    """
-    Class which mimics weighted linear regression from the statsmodels package.
-
-    However, unlike statsmodels WLS, this class also supports sample variances in addition to sample weights,
-    which enables more accurate inference when working with summarized data.
-
-    Parameters
-    ----------
-    fit_intercept : bool (optional, default=True)
-        Whether to fit an intercept in this model
-    fit_args : dict (optional, default=`{}`)
-        The statsmodels-style fit arguments; keys can include 'cov_type'
-    """
-
-    def __init__(self, fit_intercept=True, cov_type=None):
-        self.cov_type = cov_type
-        self.fit_intercept = fit_intercept
-        return
-
-    def _check_input(self, X, y, sample_weight, sample_var):
-        """Check dimensions and other assertions."""
-        if sample_weight is None:
-            sample_weight = np.ones(y.shape[0])
-        elif np.any(np.not_equal(np.mod(sample_weight, 1), 0)):
-            raise AttributeError("Sample weights must all be integers for inference to be valid!")
-
-        if sample_var is None:
-            if np.any(np.not_equal(sample_weight, 1)):
-                warnings.warn(
-                    "No variance information was given for samples with sample_weight not equal to 1, "
-                    "that represent summaries of multiple original samples. Inference will be invalid!")
-            sample_var = np.zeros(y.shape)
-
-        if sample_var.ndim < 2:
-            if np.any(np.equal(sample_weight, 1) & np.not_equal(sample_var, 0)):
-                warnings.warn(
-                    "Variance was set to non-zero for an observation with sample_weight=1! "
-                    "sample_var represents the variance of the original observations that are "
-                    "summarized in this sample. Hence, cannot have a non-zero variance if only "
-                    "one observations was summarized. Inference will be invalid!")
-        else:
-            if np.any(np.equal(sample_weight, 1) & np.not_equal(np.sum(sample_var, axis=1), 0)):
-                warnings.warn(
-                    "Variance was set to non-zero for an observation with sample_weight=1! "
-                    "sample_var represents the variance of the original observations that are "
-                    "summarized in this sample. Hence, cannot have a non-zero variance if only "
-                    "one observations was summarized. Inference will be invalid!")
-
-        if X is None:
-            X = np.empty((y.shape[0], 0))
-
-        assert (X.shape[0] == y.shape[0] ==
-                sample_weight.shape[0] == sample_var.shape[0]), "Input lengths not compatible!"
-        if y.ndim >= 2:
-            assert (y.ndim == sample_var.ndim and
-                    y.shape[1] == sample_var.shape[1]), "Input shapes not compatible: {}, {}!".format(
-                y.shape, sample_var.shape)
-
-        return X, y, sample_weight, sample_var
-
-    def fit(self, X, y, sample_weight=None, sample_var=None):
-        """
-        Fits the model.
-
-        Parameters
-        ----------
-        X : (N, d) nd array like
-            co-variates
-        y : {(N,), (N, p)} nd array like
-            output variable(s)
-        sample_weight : (N,) nd array like of integers
-            Weight for the observation. Observation i is treated as the mean
-            outcome of sample_weight[i] independent observations
-        sample_var : {(N,), (N, p)} nd array like
-            Variance of the outcome(s) of the original sample_weight[i] observations
-            that were used to compute the mean outcome represented by observation i.
-
-        Returns
-        -------
-        self : StatsModelsLinearRegression
-        """
-        # TODO: Add other types of covariance estimation (e.g. Newey-West (HAC), HC2, HC3)
-        X, y, sample_weight, sample_var = self._check_input(X, y, sample_weight, sample_var)
-
-        if self.fit_intercept:
-            X = add_constant(X, has_constant='add')
-        WX = X * np.sqrt(sample_weight).reshape(-1, 1)
-
-        if y.ndim < 2:
-            self._n_out = 0
-            wy = y * np.sqrt(sample_weight)
-        else:
-            self._n_out = y.shape[1]
-            wy = y * np.sqrt(sample_weight).reshape(-1, 1)
-
-        param, _, rank, _ = np.linalg.lstsq(WX, wy, rcond=None)
-
-        if rank < param.shape[0]:
-            warnings.warn("Co-variance matrix is undertermined. Inference will be invalid!")
-
-        sigma_inv = np.linalg.pinv(np.matmul(WX.T, WX))
-        self._param = param
-        var_i = sample_var + (y - np.matmul(X, param))**2
-        n_obs = np.sum(sample_weight)
-        df = len(param) if self._n_out == 0 else param.shape[0]
-
-        if n_obs <= df:
-            warnings.warn("Number of observations <= than number of parameters. Using biased variance calculation!")
-            correction = 1
-        else:
-            correction = (n_obs / (n_obs - df))
-
-        if (self.cov_type is None) or (self.cov_type == 'nonrobust'):
-            if y.ndim < 2:
-                self._var = correction * np.average(var_i, weights=sample_weight) * sigma_inv
-            else:
-                vars = correction * np.average(var_i, weights=sample_weight, axis=0)
-                self._var = [v * sigma_inv for v in vars]
-        elif (self.cov_type == 'HC0'):
-            if y.ndim < 2:
-                weighted_sigma = np.matmul(WX.T, WX * var_i.reshape(-1, 1))
-                self._var = np.matmul(sigma_inv, np.matmul(weighted_sigma, sigma_inv))
-            else:
-                self._var = []
-                for j in range(self._n_out):
-                    weighted_sigma = np.matmul(WX.T, WX * var_i[:, [j]])
-                    self._var.append(np.matmul(sigma_inv, np.matmul(weighted_sigma, sigma_inv)))
-        elif (self.cov_type == 'HC1'):
-            if y.ndim < 2:
-                weighted_sigma = np.matmul(WX.T, WX * var_i.reshape(-1, 1))
-                self._var = correction * np.matmul(sigma_inv, np.matmul(weighted_sigma, sigma_inv))
-            else:
-                self._var = []
-                for j in range(self._n_out):
-                    weighted_sigma = np.matmul(WX.T, WX * var_i[:, [j]])
-                    self._var.append(correction * np.matmul(sigma_inv, np.matmul(weighted_sigma, sigma_inv)))
-        else:
-            raise AttributeError("Unsupported cov_type. Must be one of nonrobust, HC0, HC1.")
-        return self
-
-    def predict(self, X):
-        """
-        Predicts the output given an array of instances.
-
-        Parameters
-        ----------
-        X : (n, d) array like
-            The covariates on which to predict
-
-        Returns
-        -------
-        predictions : {(n,) array, (n,p) array}
-            The predicted mean outcomes
-        """
-        if X is None:
-            X = np.empty((1, 0))
-        if self.fit_intercept:
-            X = add_constant(X, has_constant='add')
-        return np.matmul(X, self._param)
-
-    @property
-    def coef_(self):
-        """
-        Get the model's coefficients on the covariates.
-
-        Returns
-        -------
-        coef_ : {(d,), (p, d)} nd array like
-            The coefficients of the variables in the linear regression. If label y
-            was p-dimensional, then the result is a matrix of coefficents, whose p-th
-            row containts the coefficients corresponding to the p-th coordinate of the label.
-        """
-        if self.fit_intercept:
-            if self._n_out == 0:
-                return self._param[1:]
-            else:
-                return self._param[1:].T
-        else:
-            if self._n_out == 0:
-                return self._param
-            else:
-                return self._param.T
-
-    @property
-    def intercept_(self):
-        """
-        Get the intercept(s) (or 0 if no intercept was fit).
-
-        Returns
-        -------
-        intercept_ : float or (p,) nd array like
-            The intercept of the linear regresion. If label y was p-dimensional, then the result is a vector
-            whose p-th entry containts the intercept corresponding to the p-th coordinate of the label.
-        """
-        return self._param[0] if self.fit_intercept else (0 if self._n_out == 0 else np.zeros(self._n_out))
-
-    @property
-    def _param_var(self):
-        """
-        The covariance matrix of all the parameters in the regression (including the intercept as the first parameter).
-
-        Returns
-        -------
-        var : {(d (+1), d (+1)), (p, d (+1), d (+1))} nd array like
-            The covariance matrix of all the parameters in the regression (including the intercept
-            as the first parameter).  If intercept was set to False then this is the covariance matrix
-            of the coefficients; otherwise, the intercept is treated as the first parameter of the regression
-            and the coefficients as the remaining. If outcome y is p-dimensional, then this is a tensor whose
-            p-th entry contains the co-variance matrix for the parameters corresponding to the regression of
-            the p-th coordinate of the outcome.
-        """
-        return np.array(self._var)
-
-    @property
-    def _param_stderr(self):
-        """
-        The standard error of each parameter that was estimated.
-
-        Returns
-        -------
-        _param_stderr : {(d (+1),) (d (+1), p)} nd array like
-            The standard error of each parameter that was estimated.
-        """
-        if self._n_out == 0:
-            return np.sqrt(np.clip(np.diag(self._param_var), 0, np.inf))
-        else:
-            return np.array([np.sqrt(np.clip(np.diag(v), 0, np.inf)) for v in self._param_var]).T
-
-    @property
-    def coef_stderr_(self):
-        """
-        Gets the standard error of the fitted coefficients.
-
-        Returns
-        -------
-        coef_stderr_ : {(d,), (p, d)} nd array like
-            The standard error of the coefficients
-        """
-        return self._param_stderr[1:].T if self.fit_intercept else self._param_stderr.T
-
-    @property
-    def intercept_stderr_(self):
-        """
-        Gets the standard error of the intercept(s) (or 0 if no intercept was fit).
-
-        Returns
-        -------
-        intercept_stderr_ : float or (p,) nd array like
-            The standard error of the intercept(s)
-        """
-        return self._param_stderr[0] if self.fit_intercept else (0 if self._n_out == 0 else np.zeros(self._n_out))
-
-    def prediction_stderr(self, X):
-        """
-        Gets the standard error of the predictions.
-
-        Parameters
-        ----------
-        X : (n, d) array like
-            The covariates at which to predict
-
-        Returns
-        -------
-        prediction_stderr : (n, p) array like
-            The standard error of each coordinate of the output at each point we predict
-        """
-        if X is None:
-            X = np.empty((1, 0))
-        if self.fit_intercept:
-            X = add_constant(X, has_constant='add')
-        if self._n_out == 0:
-            return np.sqrt(np.clip(np.sum(np.matmul(X, self._param_var) * X, axis=1), 0, np.inf))
-        else:
-            return np.array([np.sqrt(np.clip(np.sum(np.matmul(X, v) * X, axis=1), 0, np.inf)) for v in self._var]).T
-
-    def coef__interval(self, alpha=.05):
-        """
-        Gets a confidence interval bounding the fitted coefficients.
-
-        Parameters
-        ----------
-        alpha : float
-            The confidence level. Will calculate the alpha/2-quantile and the (1-alpha/2)-quantile
-            of the parameter distribution as confidence interval
-
-        Returns
-        -------
-        coef__interval : {tuple ((p, d) array, (p,d) array), tuple ((d,) array, (d,) array)}
-            The lower and upper bounds of the confidence interval of the coefficients
-        """
-        return np.array([_safe_norm_ppf(alpha / 2, loc=p, scale=err)
-                         for p, err in zip(self.coef_, self.coef_stderr_)]),\
-            np.array([_safe_norm_ppf(1 - alpha / 2, loc=p, scale=err)
-                      for p, err in zip(self.coef_, self.coef_stderr_)])
-
-    def intercept__interval(self, alpha=.05):
-        """
-        Gets a confidence interval bounding the intercept(s) (or 0 if no intercept was fit).
-
-        Parameters
-        ----------
-        alpha : float
-            The confidence level. Will calculate the alpha/2-quantile and the (1-alpha/2)-quantile
-            of the parameter distribution as confidence interval
-
-        Returns
-        -------
-        intercept__interval : {tuple ((p,) array, (p,) array), tuple (float, float)}
-            The lower and upper bounds of the confidence interval of the intercept(s)
-        """
-        if not self.fit_intercept:
-            return (0 if self._n_out == 0 else np.zeros(self._n_out)),\
-                (0 if self._n_out == 0 else np.zeros(self._n_out))
-
-        if self._n_out == 0:
-            return _safe_norm_ppf(alpha / 2, loc=self.intercept_, scale=self.intercept_stderr_),\
-                _safe_norm_ppf(1 - alpha / 2, loc=self.intercept_, scale=self.intercept_stderr_)
-        else:
-            return np.array([_safe_norm_ppf(alpha / 2, loc=p, scale=err)
-                             for p, err in zip(self.intercept_, self.intercept_stderr_)]),\
-                np.array([_safe_norm_ppf(1 - alpha / 2, loc=p, scale=err)
-                          for p, err in zip(self.intercept_, self.intercept_stderr_)])
-
-    def predict_interval(self, X, alpha=.05):
-        """
-        Gets a confidence interval bounding the prediction.
-
-        Parameters
-        ----------
-        X : (n, d) array like
-            The covariates on which to predict
-        alpha : float
-            The confidence level. Will calculate the alpha/2-quantile and the (1-alpha/2)-quantile
-            of the parameter distribution as confidence interval
-
-        Returns
-        -------
-        prediction_intervals : {tuple ((n,) array, (n,) array), tuple ((n,p) array, (n,p) array)}
-            The lower and upper bounds of the confidence intervals of the predicted mean outcomes
-        """
-        return np.array([_safe_norm_ppf(alpha / 2, loc=p, scale=err)
-                         for p, err in zip(self.predict(X), self.prediction_stderr(X))]),\
-            np.array([_safe_norm_ppf(1 - alpha / 2, loc=p, scale=err)
-                      for p, err in zip(self.predict(X), self.prediction_stderr(X))])
-
-
-class LassoCVWrapper:
-    """Helper class to wrap either LassoCV or MultiTaskLassoCV depending on the shape of the target."""
-
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-
-    def fit(self, X, Y):
-        assert shape(X)[0] == shape(Y)[0]
-        assert ndim(Y) <= 2
-        self.needs_unravel = False
-        if ndim(Y) == 2 and shape(Y)[1] > 1:
-            self.model = MultiTaskLassoCV(*self.args, **self.kwargs)
-        else:
-            if ndim(Y) == 2 and shape(Y)[1] == 1:
-                Y = np.ravel(Y)
-                self.needs_unravel = True
-            self.model = LassoCV(*self.args, **self.kwargs)
-        self.model.fit(X, Y)
-        return self
-
-    def predict(self, X):
-        predictions = self.model.predict(X)
-        return reshape(predictions, (-1, 1)) if self.needs_unravel else predictions
-
-
 class Summary:
     # This class is mainly derived from statsmodels.iolib.summary.Summary
     """
@@ -1646,3 +1272,31 @@ class _RegressionWrapper:
         X : features
         """
         return self._clf.predict_proba(X)[:, 1:]
+
+
+@deprecated("This class will be removed from a future version of this package; "
+            "please use econml.sklearn_extensions.linear_model.WeightedLassoCV instead.")
+class LassoCVWrapper:
+    """Helper class to wrap either LassoCV or MultiTaskLassoCV depending on the shape of the target."""
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def fit(self, X, Y):
+        assert shape(X)[0] == shape(Y)[0]
+        assert ndim(Y) <= 2
+        self.needs_unravel = False
+        if ndim(Y) == 2 and shape(Y)[1] > 1:
+            self.model = MultiTaskLassoCV(*self.args, **self.kwargs)
+        else:
+            if ndim(Y) == 2 and shape(Y)[1] == 1:
+                Y = np.ravel(Y)
+                self.needs_unravel = True
+            self.model = LassoCV(*self.args, **self.kwargs)
+        self.model.fit(X, Y)
+        return self
+
+    def predict(self, X):
+        predictions = self.model.predict(X)
+        return reshape(predictions, (-1, 1)) if self.needs_unravel else predictions


### PR DESCRIPTION
This moves `StatsModelsLinearRegression` from the `econml.utilities` package to `econml.sklearn_extensions.linear_model` package, deprecates the unused `LassoCVWrapper`, and cleans up some of our imports a bit (fixes #118).

Given that `econml.sklearn_extensions.linear_model` imports from `econml.utilities`, I couldn't find a clean way to leave a deprecated version of this class in `utilities`, but it seems unlikely that any user directly depends on this class in a way that will break.