### PR TITLE
fixed max_samples=.5 in default grid for cfddml.tune

### DIFF
--- a/econml/dml/causal_forest.py
+++ b/econml/dml/causal_forest.py
@@ -647,7 +647,7 @@ class CausalForestDML(_BaseDML):
         Y, T, X, W, sample_weight, groups = check_input_arrays(Y, T, X, W, sample_weight, groups)
 
         if params == 'auto':
-            params = {'max_samples': [.3, .5],
+            params = {'max_samples': [.3, .45],
                       'min_balancedness_tol': [.3, .5],
                       'min_samples_leaf': [5, 50],
                       'max_depth': [3, None],


### PR DESCRIPTION
max samples=.5 doesn't work with inference, so default grid changed to [.3, .45]