### PR TITLE
Improve causal analysis functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ For information on use cases and background material on causal inference and het
 
 # News
 
-**May 18, 2021:** Release v0.11.1, see release notes [here](https://github.com/Microsoft/EconML/releases/tag/v0.11.1)
+**June 7, 2021:** Release v0.12.0b1, see release notes [here](https://github.com/Microsoft/EconML/releases/tag/v0.12.0b1)
 
 <details><summary>Previous releases</summary>
+
+**May 18, 2021:** Release v0.11.1, see release notes [here](https://github.com/Microsoft/EconML/releases/tag/v0.11.1)
 
 **May 8, 2021:** Release v0.11.0, see release notes [here](https://github.com/Microsoft/EconML/releases/tag/v0.11.0)
 

--- a/econml/__init__.py
+++ b/econml/__init__.py
@@ -26,4 +26,4 @@ __all__ = ['automated_ml',
            'dowhy',
            '__version__']
 
-__version__ = '0.11.1'
+__version__ = '0.12.0b1'

--- a/econml/dml/causal_forest.py
+++ b/econml/dml/causal_forest.py
@@ -647,11 +647,11 @@ class CausalForestDML(_BaseDML):
         Y, T, X, W, sample_weight, groups = check_input_arrays(Y, T, X, W, sample_weight, groups)
 
         if params == 'auto':
-            params = {'max_samples': [.3, .45],
-                      'min_balancedness_tol': [.3, .5],
-                      'min_samples_leaf': [5, 50],
-                      'max_depth': [3, None],
-                      'min_var_fraction_leaf': [None, .01]}
+            params = {
+                'min_weight_fraction_leaf': [0.0001, .01],
+                'max_depth': [3, 5, None],
+                'min_var_fraction_leaf': [0.001, .01]
+            }
         else:
             # If custom param grid, check that only estimator parameters are being altered
             estimator_param_names = self.tunable_params

--- a/econml/dml/causal_forest.py
+++ b/econml/dml/causal_forest.py
@@ -74,7 +74,7 @@ class _CausalForestFinalWrapper:
                      "where available.")
             residuals = Y_res - np.einsum('ijk,ik->ij', oob_preds, T_res)
             propensities = T - T_res
-            VarT = np.clip(propensities * (1 - propensities), 1e-10, np.inf)
+            VarT = np.clip(propensities * (1 - propensities), 1e-2, np.inf)
             drpreds = oob_preds
             drpreds += cross_product(residuals, T_res / VarT).reshape((-1, Y_res.shape[1], T_res.shape[1]))
             drpreds[np.isnan(oob_preds)] = np.nan

--- a/econml/policy/_forest/_tree.py
+++ b/econml/policy/_forest/_tree.py
@@ -228,7 +228,7 @@ class PolicyTree(_SingleTreeExporterMixin, BaseTree):
         self.random_seed_ = self.random_state
         self.random_state_ = check_random_state(self.random_seed_)
         if check_input:
-            X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
+            X, y = check_X_y(X, y, multi_output=True, y_numeric=True, ensure_min_features=0)
         n_y = 1 if y.ndim == 1 else y.shape[1]
         super().fit(X, y, n_y, n_y, n_y,
                     sample_weight=sample_weight, check_input=check_input)

--- a/econml/solutions/causal_analysis/_causal_analysis.py
+++ b/econml/solutions/causal_analysis/_causal_analysis.py
@@ -16,6 +16,7 @@ from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier,
 from sklearn.linear_model import Lasso, LassoCV, LogisticRegression, LogisticRegressionCV
 from sklearn.pipeline import make_pipeline, Pipeline
 from sklearn.preprocessing import OneHotEncoder, PolynomialFeatures, StandardScaler
+from sklearn.tree import _tree
 from sklearn.utils.validation import column_or_1d
 from ...cate_interpreter import SingleTreeCateInterpreter, SingleTreePolicyInterpreter
 from ...dml import LinearDML, CausalForestDML
@@ -104,60 +105,64 @@ def _get_metadata_causal_insights_keys():
             _CausalInsightsConstants.ViewKey]
 
 
-def _first_stage_reg(X, y, *, automl=True):
+def _first_stage_reg(X, y, *, automl=True, random_state=None, verbose=0):
     if automl:
-        model = GridSearchCVList([make_pipeline(StandardScaler(), LassoCV()),
+        model = GridSearchCVList([make_pipeline(StandardScaler(), LassoCV(random_state=random_state)),
                                   RandomForestRegressor(
-                                      n_estimators=100, random_state=123, min_samples_leaf=10),
-                                  lgb.LGBMRegressor(num_leaves=32)],
+                                      n_estimators=100, random_state=random_state, min_samples_leaf=10),
+                                  lgb.LGBMRegressor(num_leaves=32, random_state=random_state)],
                                  param_grid_list=[{},
                                                   {'min_weight_fraction_leaf':
                                                       [.001, .01, .1]},
                                                   {'learning_rate': [0.1, 0.3], 'max_depth': [3, 5]}],
-                                 cv=2,
-                                 scoring='neg_mean_squared_error')
+                                 cv=3,
+                                 scoring='r2',
+                                 verbose=verbose)
         best_est = model.fit(X, y).best_estimator_
         if isinstance(best_est, Pipeline):
-            return make_pipeline(StandardScaler(), Lasso(alpha=best_est.steps[1][1].alpha_))
+            return make_pipeline(StandardScaler(), Lasso(alpha=best_est.steps[1][1].alpha_, random_state=random_state))
         else:
             return best_est
     else:
-        model = make_pipeline(StandardScaler(), LassoCV(cv=5)).fit(X, y)
-        return make_pipeline(StandardScaler(), Lasso(alpha=model.steps[1][1].alpha_))
+        model = make_pipeline(StandardScaler(), LassoCV(cv=5, random_state=random_state)).fit(X, y)
+        return make_pipeline(StandardScaler(), Lasso(alpha=model.steps[1][1].alpha_, random_state=random_state))
 
 
-def _first_stage_clf(X, y, *, make_regressor=False, automl=True):
+def _first_stage_clf(X, y, *, make_regressor=False, automl=True, random_state=None, verbose=0):
     if automl:
-        model = GridSearchCVList([make_pipeline(StandardScaler(), LogisticRegression(max_iter=1000)),
-                                  RandomForestClassifier(
-                                      n_estimators=100, random_state=123),
-                                  GradientBoostingClassifier(random_state=123)],
+        model = GridSearchCVList([make_pipeline(StandardScaler(), LogisticRegression(max_iter=1000,
+                                                                                     random_state=random_state)),
+                                  RandomForestClassifier(n_estimators=100, min_samples_leaf=10,
+                                                         random_state=random_state),
+                                  lgb.LGBMClassifier(num_leaves=32, random_state=random_state)],
                                  param_grid_list=[{'logisticregression__C': [0.01, .1, 1, 10, 100]},
-                                                  {'max_depth': [3, 5],
-                                                   'min_samples_leaf': [10, 50]},
-                                                  {'n_estimators': [50, 100],
-                                                   'max_depth': [3],
-                                                   'min_samples_leaf': [10, 30]}],
-                                 cv=5,
-                                 scoring='neg_log_loss')
+                                                  {'max_depth': [3, None],
+                                                   'min_weight_fraction_leaf': [.001, .01, .1]},
+                                                  {'learning_rate': [0.1, 0.3], 'max_depth': [3, 5]}],
+                                 cv=3,
+                                 scoring='neg_log_loss',
+                                 verbose=verbose)
         est = model.fit(X, y).best_estimator_
     else:
-        model = make_pipeline(StandardScaler(), LogisticRegressionCV(cv=5, max_iter=1000)).fit(X, y)
-        est = make_pipeline(StandardScaler(), LogisticRegression(C=model.steps[1][1].C_[0]))
+        model = make_pipeline(StandardScaler(), LogisticRegressionCV(
+            cv=5, max_iter=1000, random_state=random_state)).fit(X, y)
+        est = make_pipeline(StandardScaler(), LogisticRegression(
+            C=model.steps[1][1].C_[0], random_state=random_state))
     if make_regressor:
         return _RegressionWrapper(est)
     else:
         return est
 
 
-def _final_stage():
-    return GridSearchCVList([WeightedLasso(),
-                             RandomForestRegressor(n_estimators=100, random_state=123)],
+def _final_stage(*, random_state=None, verbose=0):
+    return GridSearchCVList([WeightedLasso(random_state=random_state),
+                             RandomForestRegressor(n_estimators=100, random_state=random_state, verbose=verbose)],
                             param_grid_list=[{'alpha': [.001, .01, .1, 1, 10]},
                                              {'max_depth': [3, 5],
                                               'min_samples_leaf': [10, 50]}],
-                            cv=5,
-                            scoring='neg_mean_squared_error')
+                            cv=3,
+                            scoring='neg_mean_squared_error',
+                            verbose=verbose)
 
 
 # simplification of sklearn's ColumnTransformer that encodes categoricals and passes through selected other columns
@@ -173,8 +178,9 @@ class _ColumnTransformer(TransformerMixin):
         cat_cols = _safe_indexing(X, self.categorical, axis=1)
         if cat_cols.shape[1] > 0:
             self.has_cats = True
-            self.one_hot_encoder = OneHotEncoder(
-                drop='first', sparse=False).fit(cat_cols)
+            # NOTE: set handle_unknown to 'ignore' so that we don't throw at runtime if given a novel value
+            self.one_hot_encoder = OneHotEncoder(sparse=False,
+                                                 handle_unknown='ignore').fit(cat_cols)
         else:
             self.has_cats = False
         self.d_x = X.shape[1]
@@ -210,15 +216,172 @@ def _sanitize(obj):
     else:
         try:
             return [_sanitize(item) for item in obj]
-        except e:
+        except Exception:
             raise ValueError(f"Could not sanitize input {obj}")
+
+
+# Convert SingleTreeInterpreter to a python dictionary
+def _tree_interpreter_to_dict(interp, features, leaf_data=lambda t, n: {}):
+    tree = interp.tree_model_.tree_
+
+    def recurse(node_id):
+        if tree.children_left[node_id] == _tree.TREE_LEAF:
+            return {'leaf': True, 'n_samples': tree.n_node_samples[node_id], **leaf_data(tree, node_id)}
+        else:
+            return {'leaf': False, 'feature': features[tree.feature[node_id]], 'threshold': tree.threshold[node_id],
+                    'left': recurse(tree.children_left[node_id]),
+                    'right': recurse(tree.children_right[node_id])}
+
+    return recurse(0)
 
 
 # named tuple type for storing results inside CausalAnalysis class;
 # must be lifted to module level to enable pickling
 _result = namedtuple("_result", field_names=[
     "feature_index", "feature_name", "feature_baseline", "feature_levels", "hinds",
-    "X_transformer", "W_transformer", "estimator", "global_inference"])
+    "X_transformer", "W_transformer", "estimator", "global_inference", "treatment_value"])
+
+
+def _process_feature(name, feat_ind, verbose, categorical_inds, categories, heterogeneity_inds, y, X,
+                     nuisance_models, h_model, random_state, model_y):
+    if verbose > 0:
+        print(f"CausalAnalysis: Feature {name}")
+
+    discrete_treatment = feat_ind in categorical_inds
+    if discrete_treatment:
+        cats = categories[categorical_inds.index(feat_ind)]
+    else:
+        cats = 'auto'  # just leave the setting at the default otherwise
+
+    hinds = heterogeneity_inds[feat_ind]
+    WX_transformer = ColumnTransformer([('encode', OneHotEncoder(drop='first', sparse=False),
+                                         [ind for ind in categorical_inds
+                                             if ind != feat_ind]),
+                                        ('drop', 'drop', feat_ind)],
+                                       remainder='passthrough')
+    W_transformer = ColumnTransformer([('encode', OneHotEncoder(drop='first', sparse=False),
+                                        [ind for ind in categorical_inds
+                                            if ind != feat_ind and ind not in hinds]),
+                                       ('drop', 'drop', hinds),
+                                       ('drop_feat', 'drop', feat_ind)],
+                                      remainder='passthrough')
+    # Use _ColumnTransformer instead of ColumnTransformer so we can get feature names
+    X_transformer = _ColumnTransformer([ind for ind in categorical_inds
+                                        if ind != feat_ind and ind in hinds],
+                                       [ind for ind in hinds
+                                        if ind != feat_ind and ind not in categorical_inds])
+
+    # Controls are all other columns of X
+    WX = WX_transformer.fit_transform(X)
+    # can't use X[:, feat_ind] when X is a DataFrame
+    T = _safe_indexing(X, feat_ind, axis=1)
+
+    # TODO: we can't currently handle unseen values of the feature column when getting the effect;
+    #       we might want to modify OrthoLearner (and other discrete treatment classes)
+    #       so that the user can opt-in to allowing unseen treatment values
+    #       (and return NaN or something in that case)
+
+    W = W_transformer.fit_transform(X)
+    X_xf = X_transformer.fit_transform(X)
+    if W.shape[1] == 0:
+        # array checking routines don't accept 0-width arrays
+        W = None
+
+    if X_xf.shape[1] == 0:
+        X_xf = None
+
+    if verbose > 0:
+        print("CausalAnalysis: performing model selection on T model")
+
+    # perform model selection
+    model_t = (_first_stage_clf(WX, T, automl=nuisance_models == 'automl',
+                                random_state=random_state, verbose=verbose)
+               if discrete_treatment else _first_stage_reg(WX, T, automl=nuisance_models == 'automl',
+                                                           random_state=random_state,
+                                                           verbose=verbose))
+
+    if X_xf is None and h_model == 'forest':
+        warnings.warn(f"Using a linear model instead of a forest model for feature '{name}' "
+                      "because forests don't support models with no heterogeneity indices")
+        h_model = 'linear'
+
+    if h_model == 'linear':
+        est = LinearDML(model_y=model_y,
+                        model_t=model_t,
+                        discrete_treatment=discrete_treatment,
+                        fit_cate_intercept=True,
+                        linear_first_stages=False,
+                        categories=cats,
+                        random_state=random_state)
+    elif h_model == 'forest':
+        est = CausalForestDML(model_y=model_y,
+                              model_t=model_t,
+                              discrete_treatment=discrete_treatment,
+                              n_estimators=4000,
+                              min_var_leaf_on_val=True,
+                              categories=cats,
+                              random_state=random_state,
+                              verbose=verbose)
+
+        if verbose > 0:
+            print("CausalAnalysis: tuning forest")
+        est.tune(y, T, X=X_xf, W=W)
+    if verbose > 0:
+        print("CausalAnalysis: training causal model")
+    est.fit(y, T, X=X_xf, W=W, cache_values=True)
+
+    # Prefer ate__inference to const_marginal_ate_inference(X) because it is doubly-robust and not conservative
+    if h_model == 'forest' and discrete_treatment:
+        global_inference = est.ate__inference()
+    else:
+        # convert to NormalInferenceResults for consistency
+        inf = est.const_marginal_ate_inference(X=X_xf)
+        global_inference = NormalInferenceResults(d_t=inf.d_t, d_y=inf.d_y,
+                                                  pred=inf.mean_point,
+                                                  pred_stderr=inf.stderr_mean,
+                                                  mean_pred_stderr=None,
+                                                  inf_type='ate')
+
+    # Set the dictionary values shared between local and global summaries
+    if discrete_treatment:
+        cats = est.transformer.categories_[0]
+        baseline = cats[est.transformer.drop_idx_[0]]
+        cats = cats[np.setdiff1d(np.arange(len(cats)),
+                                 est.transformer.drop_idx_[0])]
+        d_t = len(cats)
+        insights = {
+            _CausalInsightsConstants.TypeKey: ['cat'] * d_t,
+            _CausalInsightsConstants.RawFeatureNameKey: [name] * d_t,
+            _CausalInsightsConstants.CategoricalColumnKey: cats.tolist(),
+            _CausalInsightsConstants.EngineeredNameKey: [
+                f"{name} (base={baseline}): {c}" for c in cats]
+        }
+        treatment_value = 1
+    else:
+        d_t = 1
+        cats = ["num"]
+        baseline = None
+        insights = {
+            _CausalInsightsConstants.TypeKey: ["num"],
+            _CausalInsightsConstants.RawFeatureNameKey: [name],
+            _CausalInsightsConstants.CategoricalColumnKey: [name],
+            _CausalInsightsConstants.EngineeredNameKey: [name]
+        }
+        # calculate a "typical" treatment value, using the mean of the absolute value of non-zero treatments
+        treatment_value = np.mean(np.abs(T[T != 0]))
+
+    result = _result(feature_index=feat_ind,
+                     feature_name=name,
+                     feature_baseline=baseline,
+                     feature_levels=cats,
+                     hinds=hinds,
+                     X_transformer=X_transformer,
+                     W_transformer=W_transformer,
+                     estimator=est,
+                     global_inference=global_inference,
+                     treatment_value=treatment_value)
+
+    return insights, result
 
 
 class CausalAnalysis:
@@ -267,12 +430,30 @@ class CausalAnalysis:
         of the form theta(X)=<a, X> will be used, while 'forest' means that a forest model will be trained instead.
         TODO. Add other options, such as {'automl'} for performing
         model selection for the causal effect, or {'sparse_linear'} for using a debiased lasso. (post-MVP)
+    categories: 'auto' or list of ('auto' or list of values), default 'auto'
+        What categories to use for the categorical columns.  If 'auto', then the categories will be inferred for
+        all categorical columns; otherwise this argument should have as many entries as there are categorical columns,
+        and each entry should be either 'auto' to infer the values for that column or the list of values for the
+        column. If explicit values are provided, the first value is treated as the "control" value for that column
+        against which other values are compared.
     n_jobs: int, default -1
         Degree of parallelism to use when training models via joblib.Parallel
+    verbose : int, default=0
+        Controls the verbosity when fitting and predicting.
+    random_state : int, RandomState instance or None, default=None
+        Controls the randomness of the estimator. The features are always
+        randomly permuted at each split. When ``max_features < n_features``, the algorithm will
+        select ``max_features`` at random at each split before finding the best
+        split among them. But the best found split may vary across different
+        runs, even if ``max_features=n_features``. That is the case, if the
+        improvement of the criterion is identical for several splits and one
+        split has to be selected at random. To obtain a deterministic behaviour
+        during fitting, ``random_state`` has to be fixed to an integer.
     """
 
     def __init__(self, feature_inds, categorical, heterogeneity_inds=None, feature_names=None, classification=False,
-                 upper_bound_on_cat_expansion=5, nuisance_models='linear', heterogeneity_model='linear', n_jobs=-1):
+                 upper_bound_on_cat_expansion=5, nuisance_models='linear', heterogeneity_model='linear', *,
+                 categories='auto', n_jobs=-1, verbose=0, random_state=None):
         self.feature_inds = feature_inds
         self.categorical = categorical
         self.heterogeneity_inds = heterogeneity_inds
@@ -281,7 +462,10 @@ class CausalAnalysis:
         self.upper_bound_on_cat_expansion = upper_bound_on_cat_expansion
         self.nuisance_models = nuisance_models
         self.heterogeneity_model = heterogeneity_model
+        self.categories = categories
         self.n_jobs = n_jobs
+        self.verbose = verbose
+        self.random_state = random_state
 
     def fit(self, X, y, warm_start=False):
         """
@@ -351,10 +535,12 @@ class CausalAnalysis:
                               for ind, hinds in zip(train_inds, heterogeneity_inds)}
 
         if warm_start:
+            train_y_model = False
             if self.nuisance_models != self.nuisance_models_:
                 warnings.warn("warm_start will be ignored since the nuisance models have changed "
                               f"from {self.nuisance_models_} to {self.nuisance_models} since the previous call to fit")
                 warm_start = False
+                train_y_model = True
 
             if self.heterogeneity_model != self.heterogeneity_model_:
                 warnings.warn("warm_start will be ignored since the heterogeneity model has changed "
@@ -362,7 +548,9 @@ class CausalAnalysis:
                               "since the previous call to fit")
                 warm_start = False
 
-            # TODO: bail out also if categorical columns, classification changed?
+            # TODO: bail out also if categorical columns, classification, random_state changed?
+        else:
+            train_y_model = True
 
         # TODO: should we also train a new model_y under any circumstances when warm_start is True?
         if warm_start:
@@ -374,19 +562,24 @@ class CausalAnalysis:
             self._cache = {}  # store mapping from feature to insights, results
 
             # train the Y model
+            if train_y_model:
+                # perform model selection for the Y model using all X, not on a per-column basis
+                allX = ColumnTransformer([('encode',
+                                           OneHotEncoder(
+                                               drop='first', sparse=False),
+                                           self.categorical)],
+                                         remainder='passthrough').fit_transform(X)
 
-            # perform model selection for the Y model using all X, not on a per-column basis
-            allX = ColumnTransformer([('encode',
-                                       OneHotEncoder(
-                                           drop='first', sparse=False),
-                                       self.categorical)],
-                                     remainder='passthrough').fit_transform(X)
+                if self.verbose > 0:
+                    print("CausalAnalysis: performing model selection on overall Y model")
 
-            if self.classification:
-                self._model_y = _first_stage_clf(
-                    allX, y, automl=self.nuisance_models == 'automl', make_regressor=True)
-            else:
-                self._model_y = _first_stage_reg(allX, y, automl=self.nuisance_models == 'automl')
+                if self.classification:
+                    self._model_y = _first_stage_clf(allX, y, automl=self.nuisance_models == 'automl',
+                                                     make_regressor=True,
+                                                     random_state=self.random_state, verbose=self.verbose)
+                else:
+                    self._model_y = _first_stage_reg(allX, y, automl=self.nuisance_models == 'automl',
+                                                     random_state=self.random_state, verbose=self.verbose)
 
         if self.classification:
             # now that we've trained the classifier and wrapped it, ensure that y is transformed to
@@ -417,11 +610,22 @@ class CausalAnalysis:
             'upper_bound_on_cat_expansion': _sanitize(self.upper_bound_on_cat_expansion),
             'nuisance_models': _sanitize(self.nuisance_models),
             'heterogeneity_model': _sanitize(self.heterogeneity_model),
-            'n_jobs': _sanitize(self.n_jobs)
+            'categories': _sanitize(self.categories),
+            'n_jobs': _sanitize(self.n_jobs),
+            'verbose': _sanitize(self.verbose),
+            'random_state': _sanitize(self.random_state)
         }
 
         # convert categorical indicators to numeric indices
         categorical_inds = _get_column_indices(X, self.categorical)
+
+        categories = self.categories
+        if categories == 'auto':
+            categories = ['auto' for _ in categorical_inds]
+        else:
+            assert len(categories) == len(categorical_inds), (
+                "If categories is not 'auto', it must contain one entry per categorical column.  Instead, categories"
+                f"has length {len(categories)} while there are {len(categorical_inds)} categorical columns.")
 
         # check for indices over the categorical expansion bound
         over_bound_inds = []
@@ -441,114 +645,6 @@ class CausalAnalysis:
                 raise ValueError("No features remain; increase the upper_bound_on_cat_expansion so that at least "
                                  "one feature model can be trained.")
 
-        def process_feature(name, feat_ind):
-            discrete_treatment = feat_ind in categorical_inds
-            hinds = heterogeneity_inds[feat_ind]
-            WX_transformer = ColumnTransformer([('encode', OneHotEncoder(drop='first', sparse=False),
-                                                 [ind for ind in categorical_inds
-                                                  if ind != feat_ind]),
-                                                ('drop', 'drop', feat_ind)],
-                                               remainder='passthrough')
-            W_transformer = ColumnTransformer([('encode', OneHotEncoder(drop='first', sparse=False),
-                                                [ind for ind in categorical_inds
-                                                 if ind != feat_ind and ind not in hinds]),
-                                               ('drop', 'drop', hinds),
-                                               ('drop_feat', 'drop', feat_ind)],
-                                              remainder='passthrough')
-            # Use _ColumnTransformer instead of ColumnTransformer so we can get feature names
-            X_transformer = _ColumnTransformer([ind for ind in categorical_inds
-                                                if ind != feat_ind and ind in hinds],
-                                               [ind for ind in hinds
-                                                if ind != feat_ind and ind not in categorical_inds])
-
-            # Controls are all other columns of X
-            WX = WX_transformer.fit_transform(X)
-            # can't use X[:, feat_ind] when X is a DataFrame
-            T = _safe_indexing(X, feat_ind, axis=1)
-
-            W = W_transformer.fit_transform(X)
-            X_xf = X_transformer.fit_transform(X)
-            if W.shape[1] == 0:
-                # array checking routines don't accept 0-width arrays
-                W = None
-
-            if X_xf.shape[1] == 0:
-                X_xf = None
-
-            # perform model selection
-            model_t = (_first_stage_clf(WX, T, automl=self.nuisance_models == 'automl')
-                       if discrete_treatment else _first_stage_reg(WX, T, automl=self.nuisance_models == 'automl'))
-
-            h_model = self.heterogeneity_model
-            if X_xf is None:
-                warnings.warn(f"Using a linear model instead of a forest model for feature '{name}' "
-                              "because forests don't support models with no heterogeneity indices")
-                h_model = 'linear'
-
-            if h_model == 'linear':
-                est = LinearDML(model_y=self._model_y,
-                                model_t=model_t,
-                                discrete_treatment=discrete_treatment,
-                                fit_cate_intercept=True,
-                                linear_first_stages=False,
-                                random_state=123)
-            elif h_model == 'forest':
-                est = CausalForestDML(model_y=self._model_y,
-                                      model_t=model_t,
-                                      discrete_treatment=discrete_treatment,
-                                      n_estimators=4000,
-                                      random_state=123)
-                est.tune(y, T, X=X_xf, W=W)
-            est.fit(y, T, X=X_xf, W=W, cache_values=True)
-
-            # Prefer ate__inference to const_marginal_ate_inference(X) because it is doubly-robust and not conservative
-            if h_model == 'forest' and discrete_treatment:
-                global_inference = est.ate__inference()
-            else:
-                # convert to NormalInferenceResults for consistency
-                inf = est.const_marginal_ate_inference(X=X_xf)
-                global_inference = NormalInferenceResults(d_t=inf.d_t, d_y=inf.d_y,
-                                                          pred=inf.mean_point,
-                                                          pred_stderr=inf.stderr_mean,
-                                                          mean_pred_stderr=None,
-                                                          inf_type='ate')
-
-            # Set the dictionary values shared between local and global summaries
-            if discrete_treatment:
-                cats = est.transformer.categories_[0]
-                baseline = cats[est.transformer.drop_idx_[0]]
-                cats = cats[np.setdiff1d(np.arange(len(cats)),
-                                         est.transformer.drop_idx_[0])]
-                d_t = len(cats)
-                insights = {
-                    _CausalInsightsConstants.TypeKey: ['cat'] * d_t,
-                    _CausalInsightsConstants.RawFeatureNameKey: [name] * d_t,
-                    _CausalInsightsConstants.CategoricalColumnKey: cats.tolist(),
-                    _CausalInsightsConstants.EngineeredNameKey: [
-                        f"{name} (base={baseline}): {c}" for c in cats]
-                }
-            else:
-                d_t = 1
-                cats = ["num"]
-                baseline = None
-                insights = {
-                    _CausalInsightsConstants.TypeKey: ["num"],
-                    _CausalInsightsConstants.RawFeatureNameKey: [name],
-                    _CausalInsightsConstants.CategoricalColumnKey: [name],
-                    _CausalInsightsConstants.EngineeredNameKey: [name]
-                }
-            result = _result(feature_index=feat_ind,
-                             feature_name=name,
-                             feature_baseline=baseline,
-                             feature_levels=cats,
-                             hinds=hinds,
-                             X_transformer=X_transformer,
-                             W_transformer=W_transformer,
-                             estimator=est,
-                             global_inference=global_inference)
-
-            return insights, result
-
         if self.feature_names is None:
             if hasattr(X, "iloc"):
                 feature_names = X.columns
@@ -563,9 +659,14 @@ class CausalAnalysis:
         new_feat_names = _safe_indexing(feature_names, new_inds)
 
         cache_updates = dict(zip(new_inds,
-                                 joblib.Parallel(n_jobs=self.n_jobs,
-                                                 verbose=1)(joblib.delayed(process_feature)(feat_name, feat_ind)
-                                                            for feat_name, feat_ind in zip(new_feat_names, new_inds))))
+                                 joblib.Parallel(
+                                     n_jobs=self.n_jobs,
+                                     verbose=self.verbose
+                                 )(joblib.delayed(_process_feature)(
+                                     feat_name, feat_ind,
+                                     self.verbose, categorical_inds, categories, heterogeneity_inds, y, X,
+                                     self.nuisance_models, self.heterogeneity_model, self.random_state, self._model_y)
+                                   for feat_name, feat_ind in zip(new_feat_names, new_inds))))
 
         self._cache.update(cache_updates)
 
@@ -633,13 +734,16 @@ class CausalAnalysis:
             # add singleton treatment dimension if missing
             return arr if arr.ndim == 3 else np.expand_dims(arr, axis=2)
 
+        # store set of inference results so we don't need to recompute per-attribute below in summary/coalesce
+        infs = [get_inference(res) for res in self._results]
+
         # each attr has dimension (m,y) or (m,y,t)
         def coalesce(attr):
             """Join together the arrays for each feature"""
             attr = self._make_accessor(attr)
             # concatenate along treatment dimension
-            arr = np.concatenate([ensure_proper_dims(attr(get_inference(res)))
-                                  for res in self._results], axis=2)
+            arr = np.concatenate([ensure_proper_dims(attr(inf))
+                                  for inf in infs], axis=2)
 
             # for dictionary representation, want to remove unneeded sample dimension
             # in cohort and global results
@@ -892,30 +996,7 @@ class CausalAnalysis:
         (result,) = results
         return result
 
-    def whatif(self, X, Xnew, feature_index, y):
-        """
-        Get counterfactual predictions when feature_index is changed to Xnew from its observational counterpart.
-
-        Note that this only applies to regression use cases; for classification what-if analysis is not supported.
-
-        Parameters
-        ----------
-        X: array-like
-            Features
-        Xnew: array-like
-            New values of a single column of X
-        feature_index: int or string
-            The index of the feature being varied to Xnew, either as a numeric index or
-            the string name if the input is a dataframe
-        y: array-like
-            Observed labels or outcome of a predictive model for baseline y values
-
-        Returns
-        -------
-        y_new: InferenceResults
-            The predicted outputs that would have been observed under the counterfactual features
-        """
-
+    def _whatif_inference(self, X, Xnew, feature_index, y):
         assert not self.classification, "What-if analysis cannot be applied to classification tasks"
 
         assert np.shape(X)[0] == np.shape(Xnew)[0] == np.shape(y)[0], (
@@ -938,6 +1019,34 @@ class CausalAnalysis:
 
         return inf
 
+    def whatif(self, X, Xnew, feature_index, y, *, alpha=0.1):
+        """
+        Get counterfactual predictions when feature_index is changed to Xnew from its observational counterpart.
+
+        Note that this only applies to regression use cases; for classification what-if analysis is not supported.
+
+        Parameters
+        ----------
+        X: array-like
+            Features
+        Xnew: array-like
+            New values of a single column of X
+        feature_index: int or string
+            The index of the feature being varied to Xnew, either as a numeric index or
+            the string name if the input is a dataframe
+        y: array-like
+            Observed labels or outcome of a predictive model for baseline y values
+        alpha : float in [0, 1], default 0.1
+            Confidence level of the confidence intervals displayed in the leaf nodes.
+            A (1-alpha)*100% confidence interval is displayed.
+
+        Returns
+        -------
+        y_new: DataFrame
+            The predicted outputs that would have been observed under the counterfactual features
+        """
+        return self._whatif_inference(X, Xnew, feature_index, y).summary_frame(alpha=alpha)
+
     def _whatif_dict(self, X, Xnew, feature_index, y, alpha=0.1):
         """
         Get counterfactual predictions when feature_index is changed to Xnew from its observational counterpart.
@@ -955,59 +1064,82 @@ class CausalAnalysis:
             the string name if the input is a dataframe
         y: array-like
             Observed labels or outcome of a predictive model for baseline y values
-        alpha: float, default 0.1
-            The confidence level used for confidence intervals in the output
-
+        alpha : float in [0, 1], default 0.1
+            Confidence level of the confidence intervals displayed in the leaf nodes.
+            A (1-alpha)*100% confidence interval is displayed.
         Returns
         -------
         dict : dict
             The counterfactual predictions, as a dictionary
         """
 
-        inf = self.whatif(X, Xnew, feature_index, y)
+        inf = self._whatif_inference(X, Xnew, feature_index, y)
         props = self._point_props(alpha=alpha)
         res = _get_default_specific_insights('whatif')
         res.update([(key, self._make_accessor(attr)(inf).tolist()) for key, attr in props])
         return res
 
-    def _tree(self, is_policy, Xtest, feature_index, *, treatment_cost=0,
-              max_depth=3, min_samples_leaf=2, min_impurity_decrease=1e-4, alpha=.1):
+    def _tree(self, is_policy, Xtest, feature_index, *, treatment_costs=0,
+              max_depth=3, min_samples_leaf=2, min_impurity_decrease=1e-4,
+              include_model_uncertainty=False, alpha=.1):
 
         result = self._safe_result_index(Xtest, feature_index)
         Xtest = result.X_transformer.transform(Xtest)
         if Xtest.shape[1] == 0:
             Xtest = None
         if result.feature_baseline is None:
-            treatment_names = ['low', 'high']
+            treatment_names = ['decrease', 'increase']
         else:
             treatment_names = [f"{result.feature_baseline}"] + \
                 [f"{lvl}" for lvl in result.feature_levels]
 
-        if len(treatment_names) > 2 and is_policy:
-            raise AssertionError("Can't create policy trees for multi-class features, "
-                                 f"but this feature has values {treatment_names}")
-
         TreeType = SingleTreePolicyInterpreter if is_policy else SingleTreeCateInterpreter
-        intrp = TreeType(include_model_uncertainty=True,
+        intrp = TreeType(include_model_uncertainty=include_model_uncertainty,
                          uncertainty_level=alpha,
                          max_depth=max_depth,
                          min_samples_leaf=min_samples_leaf,
-                         min_impurity_decrease=min_impurity_decrease)
+                         min_impurity_decrease=min_impurity_decrease,
+                         random_state=self.random_state)
 
         if is_policy:
             intrp.interpret(result.estimator, Xtest,
-                            sample_treatment_costs=treatment_cost)
-            treat = intrp.treat(Xtest)
-        else:  # no treatment cost for CATE trees
-            intrp.interpret(result.estimator, Xtest)
-            treat = None
+                            sample_treatment_costs=treatment_costs)
+            if result.feature_baseline is None:  # continuous treatment, so apply a treatment level 10% of typical
+                treatment_level = result.treatment_value * 0.1
 
-        return intrp, result.X_transformer.get_feature_names(self.feature_names_), treatment_names, treat
+                # NOTE: this calculation is correct only if treatment costs are marginal costs,
+                #       because then scaling the difference between treatment value and treatment costs is the
+                #       same as scaling the treatment value and subtracting the scaled treatment cost.
+                #
+                #       Note also that unlike the standard outputs of the SinglePolicyTreeInterpreter, for
+                #       continuous treatments, the policy value should include the benefit of decreasing treatments
+                #       (rather than just not treating at all)
+                #
+                #       We can get the total by seeing that if we restrict attention to units where we would treat,
+                #         2 * policy_value - always_treat
+                #       includes exactly their contribution because policy_value and always_treat both include it
+                #       and likewise restricting attention to the units where we want to decrease treatment,
+                #         2 * policy_value - always-treat
+                #       also computes the *benefit* of decreasing treatment, because their contribution to policy_value
+                #       is zero and the contribution to always_treat is negative
+                treatment_total = (2 * intrp.policy_value_ - intrp.always_treat_value_.item()) * treatment_level
+                always_totals = intrp.always_treat_value_ * treatment_level
+            else:
+                treatment_total = intrp.policy_value_
+                always_totals = intrp.always_treat_value_
+
+            policy_values = treatment_total, always_totals
+        else:  # no policy values for CATE trees
+            intrp.interpret(result.estimator, Xtest)
+            policy_values = None
+
+        return intrp, result.X_transformer.get_feature_names(self.feature_names_), treatment_names, policy_values
 
     # TODO: it seems like it would be better to just return the tree itself rather than plot it;
     #       however, the tree can't store the feature and treatment names we compute here...
-    def plot_policy_tree(self, Xtest, feature_index, *, treatment_cost=0,
-                         max_depth=3, min_samples_leaf=2, min_value_increase=1e-4, alpha=.1):
+    def plot_policy_tree(self, Xtest, feature_index, *, treatment_costs=0,
+                         max_depth=3, min_samples_leaf=2, min_value_increase=1e-4, include_model_uncertainty=False,
+                         alpha=.1):
         """
         Plot a recommended policy tree using matplotlib.
 
@@ -1017,33 +1149,42 @@ class CausalAnalysis:
             Features
         feature_index
             Index of the feature to be considered as treament
-        treatment_cost : int, or array-like of same length as number of rows of X, optional (default=0)
-            Cost of treatment, or cost of treatment for each sample
+        treatment_costs: array-like, default 0
+            Cost of treatment, as a scalar value or per-sample. For continuous features this is the marginal cost per
+            unit of treatment; for discrete features, this is the difference in cost between each of the non-default
+            values and the default value (i.e., if non-scalar the array should have shape (n,d_t-1))
         max_depth : int, optional (default=3)
             maximum depth of the tree
         min_samples_leaf : int, optional (default=2)
             minimum number of samples on each leaf
         min_value_increase : float, optional (default=1e-4)
             The minimum increase in the policy value that a split needs to create to construct it
+        include_model_uncertainty : bool, default False
+            Whether to include confidence interval information when building a simplified model of the cate model.
         alpha : float in [0, 1], optional (default=.1)
             Confidence level of the confidence intervals displayed in the leaf nodes.
             A (1-alpha)*100% confidence interval is displayed.
         """
         intrp, feature_names, treatment_names, _ = self._tree(True, Xtest, feature_index,
-                                                              treatment_cost=treatment_cost,
+                                                              treatment_costs=treatment_costs,
                                                               max_depth=max_depth,
                                                               min_samples_leaf=min_samples_leaf,
                                                               min_impurity_decrease=min_value_increase,
+                                                              include_model_uncertainty=include_model_uncertainty,
                                                               alpha=alpha)
         return intrp.plot(feature_names=feature_names, treatment_names=treatment_names)
 
-    def _policy_tree_output(self, Xtest, feature_index, *, treatment_cost=0,
+    def _policy_tree_output(self, Xtest, feature_index, *, treatment_costs=0,
                             max_depth=3, min_samples_leaf=2, min_value_increase=1e-4, alpha=.1):
         """
-        Get a tuple policy outputs.
+        Get a tuple of policy outputs.
 
-        The first item in the tuple is the recommended policy tree in graphviz format as a string.
-        The second item is the recommended treatment for each sample as a list.
+        The first item in the tuple is the recommended policy tree expressed as a dictionary.
+        The second item is the per-unit-average value of applying the learned policy; if the feature is continuous this
+        means the gain from increasing the treatment by 10% of the typical amount for units where the treatment should
+        be increased and decreasing the treatment by 10% of the typical amount when not.
+        The third item is the value of always treating.  This is a list, with one entry per non-control-treatment for
+        discrete features, or just a single entry for continuous features, again increasing by 10% of a typical amount.
 
         Parameters
         ----------
@@ -1051,8 +1192,10 @@ class CausalAnalysis:
             Features
         feature_index
             Index of the feature to be considered as treament
-        treatment_cost : int, or array-like of same length as number of rows of X, optional (default=0)
-            Cost of treatment, or cost of treatment for each sample
+        treatment_costs: array-like, default 0
+            Cost of treatment, as a scalar value or per-sample. For continuous features this is the marginal cost per
+            unit of treatment; for discrete features, this is the difference in cost between each of the non-default
+            values and the default value (i.e., if non-scalar the array should have shape (n,d_t-1))
         max_depth : int, optional (default=3)
             maximum depth of the tree
         min_samples_leaf : int, optional (default=2)
@@ -1065,23 +1208,29 @@ class CausalAnalysis:
 
         Returns
         -------
-        tree : tuple of string, list of int
-            The policy tree represented as a graphviz string and the recommended treatment for each row
+        tree : tuple of string, float, list of float
+            The policy tree represented as a graphviz string,
+            the value of applying the recommended policy (over never treating),
+            the value of always treating (over never treating) for each non-control treatment
         """
 
-        intrp, feature_names, treatment_names, treat = self._tree(True, Xtest, feature_index,
-                                                                  treatment_cost=treatment_cost,
-                                                                  max_depth=max_depth,
-                                                                  min_samples_leaf=min_samples_leaf,
-                                                                  min_impurity_decrease=min_value_increase,
-                                                                  alpha=alpha)
-        return intrp.export_graphviz(feature_names=feature_names,
-                                     treatment_names=treatment_names), treat.tolist()
+        (intrp, feature_names, treatment_names,
+            (policy_val, always_trt)) = self._tree(True, Xtest, feature_index,
+                                                   treatment_costs=treatment_costs,
+                                                   max_depth=max_depth,
+                                                   min_samples_leaf=min_samples_leaf,
+                                                   min_impurity_decrease=min_value_increase,
+                                                   alpha=alpha)
+
+        def policy_data(tree, node_id):
+            return {'treatment': treatment_names[np.argmax(tree.value[node_id])]}
+        return _tree_interpreter_to_dict(intrp, feature_names, policy_data), policy_val, always_trt.tolist()
 
     # TODO: it seems like it would be better to just return the tree itself rather than plot it;
     #       however, the tree can't store the feature and treatment names we compute here...
     def plot_heterogeneity_tree(self, Xtest, feature_index, *,
                                 max_depth=3, min_samples_leaf=2, min_impurity_decrease=1e-4,
+                                include_model_uncertainty=False,
                                 alpha=.1):
         """
         Plot an effect hetergoeneity tree using matplotlib.
@@ -1099,6 +1248,8 @@ class CausalAnalysis:
         min_impurity_decrease : float, optional (default=1e-4)
             The minimum decrease in the impurity/uniformity of the causal effect that a split needs to
             achieve to construct it
+        include_model_uncertainty : bool, default False
+            Whether to include confidence interval information when building a simplified model of the cate model.
         alpha : float in [0, 1], optional (default=.1)
             Confidence level of the confidence intervals displayed in the leaf nodes.
             A (1-alpha)*100% confidence interval is displayed.
@@ -1108,15 +1259,16 @@ class CausalAnalysis:
                                                               max_depth=max_depth,
                                                               min_samples_leaf=min_samples_leaf,
                                                               min_impurity_decrease=min_impurity_decrease,
+                                                              include_model_uncertainty=include_model_uncertainty,
                                                               alpha=alpha)
         return intrp.plot(feature_names=feature_names,
                           treatment_names=treatment_names)
 
-    def _heterogeneity_tree_string(self, Xtest, feature_index, *,
+    def _heterogeneity_tree_output(self, Xtest, feature_index, *,
                                    max_depth=3, min_samples_leaf=2, min_impurity_decrease=1e-4,
                                    alpha=.1):
         """
-        Get an effect hetergoeneity tree in graphviz format as a string.
+        Get an effect heterogeneity tree expressed as a dictionary.
 
         Parameters
         ----------
@@ -1136,10 +1288,120 @@ class CausalAnalysis:
             A (1-alpha)*100% confidence interval is displayed.
         """
 
-        intrp, feature_names, treatment_names, _ = self._tree(False, Xtest, feature_index,
-                                                              max_depth=max_depth,
-                                                              min_samples_leaf=min_samples_leaf,
-                                                              min_impurity_decrease=min_impurity_decrease,
-                                                              alpha=alpha)
-        return intrp.export_graphviz(feature_names=feature_names,
-                                     treatment_names=treatment_names)
+        intrp, feature_names, _, _ = self._tree(False, Xtest, feature_index,
+                                                max_depth=max_depth,
+                                                min_samples_leaf=min_samples_leaf,
+                                                min_impurity_decrease=min_impurity_decrease,
+                                                alpha=alpha)
+
+        def hetero_data(tree, node_id):
+            return {'effect': _sanitize(tree.value[node_id])}
+        return _tree_interpreter_to_dict(intrp, feature_names, hetero_data)
+
+    def individualized_policy(self, Xtest, feature_index, *, n_rows=None, treatment_costs=0, alpha=0.1):
+        """
+        Get individualized treatment policy based on the learned model for a feature, sorted by the predicted effect.
+
+        Parameters
+        ----------
+        Xtest: array-like
+            Features
+        feature_index: int or string
+            Index of the feature to be considered as treatment
+        n_rows: int, optional
+            How many rows to return (all rows by default)
+        treatment_costs: array-like, default 0
+            Cost of treatment, as a scalar value or per-sample. For continuous features this is the marginal cost per
+            unit of treatment; for discrete features, this is the difference in cost between each of the non-default
+            values and the default value (i.e., if non-scalar the array should have shape (n,d_t-1))
+        alpha: float in [0, 1], default 0.1
+            Confidence level of the confidence intervals
+            A (1-alpha)*100% confidence interval is returned
+
+        Returns
+        -------
+        output: DataFrame
+            Dataframe containing recommended treatment, effect, confidence interval, sorted by effect
+        """
+        result = self._safe_result_index(Xtest, feature_index)
+
+        # get dataframe with all but selected column
+        orig_df = pd.DataFrame(Xtest, columns=self.feature_names_).rename(
+            columns={self.feature_names_[result.feature_index]: 'Current treatment'})
+
+        Xtest = result.X_transformer.transform(Xtest)
+        if Xtest.shape[1] == 0:
+            Xtest = None
+
+        if result.feature_baseline is None:
+            # apply 10% of a typical treatment for this feature
+            effect = result.estimator.effect_inference(Xtest, T1=result.treatment_value * 0.1)
+        else:
+            effect = result.estimator.const_marginal_effect_inference(Xtest)
+
+        effect.translate(-treatment_costs)
+
+        est = effect.point_estimate
+        est_lb = effect.conf_int(alpha)[0]
+        est_ub = effect.conf_int(alpha)[1]
+
+        if result.feature_baseline is None:
+            rec = np.empty(est.shape[0], dtype=object)
+            rec[est > 0] = "increase"
+            rec[est <= 0] = "decrease"
+            # set the effect bounds; for positive treatments these agree with
+            # the estimates; for negative treatments, we need to invert the interval
+            eff_lb, eff_ub = est_lb, est_ub
+            eff_lb[est <= 0], eff_ub[est <= 0] = -eff_ub[est <= 0], -eff_lb[est <= 0]
+            # the effect is now always positive since we decrease treatment when negative
+            eff = np.abs(est)
+        else:
+            # for discrete treatment, stack a zero result in front for control
+            zeros = np.zeros((est.shape[0], 1))
+            all_effs = np.hstack([zeros, est])
+            eff_ind = np.argmax(all_effs, axis=1)
+            all_eff_lbs = np.hstack([zeros, est_lb])
+            all_eff_ubs = np.hstack([zeros, est_ub])
+            treatment_arr = np.array([result.feature_baseline] + [lvl for lvl in result.feature_levels], dtype=object)
+            rec = treatment_arr[eff_ind]
+            eff_ind = eff_ind.reshape(-1, 1)
+            eff = np.take_along_axis(all_effs, eff_ind, 1).reshape(-1)
+            eff_lb = np.take_along_axis(all_eff_lbs, eff_ind, 1).reshape(-1)
+            eff_ub = np.take_along_axis(all_eff_ubs, eff_ind, 1).reshape(-1)
+
+        df = pd.DataFrame({'Treatment': rec,
+                           'Effect of treatment': eff,
+                           'Effect of treatment lower bound': eff_lb,
+                           'Effect of treatment upper bound': eff_ub},
+                          index=orig_df.index)
+
+        return df.join(orig_df).sort_values('Effect of treatment',
+                                            ascending=False).head(n_rows)
+
+    def _individualized_policy_dict(self, Xtest, feature_index, *, n_rows=None, treatment_costs=0, alpha=0.1):
+        """
+        Get individualized treatment policy based on the learned model for a feature, sorted by the predicted effect.
+
+        Parameters
+        ----------
+        Xtest: array-like
+            Features
+        feature_index: int or string
+            Index of the feature to be considered as treatment
+        n_rows: int, optional
+            How many rows to return (all rows by default)
+        treatment_costs: array-like, default 0
+            Cost of treatment, as a scalar value or per-sample
+        alpha: float in [0, 1], default 0.1
+            Confidence level of the confidence intervals
+            A (1-alpha)*100% confidence interval is returned
+
+        Returns
+        -------
+        output: dictionary
+            dictionary containing treatment policy, effects, and other columns
+        """
+        return self.individualized_policy(Xtest, feature_index,
+                                          n_rows=n_rows,
+                                          treatment_costs=treatment_costs,
+                                          alpha=alpha).to_dict('list')

--- a/econml/tests/test_causal_analysis.py
+++ b/econml/tests/test_causal_analysis.py
@@ -3,10 +3,15 @@
 
 import unittest
 import numpy as np
+from numpy.core.fromnumeric import squeeze
 import pandas as pd
 from contextlib import ExitStack
 from econml.solutions.causal_analysis import CausalAnalysis
 from econml.solutions.causal_analysis._causal_analysis import _CausalInsightsConstants
+
+
+def assert_less_close(arr1, arr2):
+    assert np.all(np.logical_or(arr1 <= arr2, np.isclose(arr1, arr2)))
 
 
 class TestCausalAnalysis(unittest.TestCase):
@@ -44,13 +49,19 @@ class TestCausalAnalysis(unittest.TestCase):
                 coh_point_est = np.array(coh_dict[_CausalInsightsConstants.PointEstimateKey])
                 loc_point_est = np.array(loc_dict[_CausalInsightsConstants.PointEstimateKey])
 
-                ca._policy_tree_output(X, 1)
-                ca._heterogeneity_tree_string(X, 1)
-                ca._heterogeneity_tree_string(X, 3)
+                ca._heterogeneity_tree_output(X, 1)
+                ca._heterogeneity_tree_output(X, 3)
 
-                # Can't handle multi-dimensional treatments
-                with self.assertRaises(AssertionError):
-                    ca._policy_tree_output(X, 3)
+                # Make sure we handle continuous, binary, and multi-class treatments
+                # For multiple discrete treatments, one "always treat" value per non-default treatment
+                for (idx, length) in [(0, 1), (1, 1), (2, 1), (3, 2)]:
+                    _, policy_val, always_trt = ca._policy_tree_output(X, idx)
+                    assert isinstance(always_trt, list)
+                    assert np.array(policy_val).shape == ()
+                    assert np.array(always_trt).shape == (length,)
+
+                    # policy value should exceed always treating with any treatment
+                    assert_less_close(always_trt, policy_val)
 
                 # global shape is (d_y, sum(d_t))
                 assert glo_point_est.shape == coh_point_est.shape == (1, 5)
@@ -62,11 +73,9 @@ class TestCausalAnalysis(unittest.TestCase):
                     cm = self.assertRaises(Exception)
                 with cm:
                     inf = ca.whatif(X[:2], np.ones(shape=(2,)), 1, y[:2])
-                    assert np.shape(inf.point_estimate) == np.shape(y[:2])
-                    inf.summary_frame()
+                    assert np.shape(inf.point_estimate) == (2,)
                     inf = ca.whatif(X[:2], np.ones(shape=(2,)), 2, y[:2])
-                    assert np.shape(inf.point_estimate) == np.shape(y[:2])
-                    inf.summary_frame()
+                    assert np.shape(inf.point_estimate) == (2,)
 
                     ca._whatif_dict(X[:2], np.ones(shape=(2,)), 1, y[:2])
 
@@ -133,13 +142,20 @@ class TestCausalAnalysis(unittest.TestCase):
                 assert glo_point_est.shape == coh_point_est.shape == (1, 5)
                 assert loc_point_est.shape == (2,) + glo_point_est.shape
 
-                ca._policy_tree_output(X, inds[1])
-                ca._heterogeneity_tree_string(X, inds[1])
-                ca._heterogeneity_tree_string(X, inds[3])
+                pto = ca._policy_tree_output(X, inds[1])
+                ca._heterogeneity_tree_output(X, inds[1])
+                ca._heterogeneity_tree_output(X, inds[3])
 
-                # Can't handle multi-dimensional treatments
-                with self.assertRaises(AssertionError):
-                    ca._policy_tree_output(X, inds[3])
+                # Make sure we handle continuous, binary, and multi-class treatments
+                # For multiple discrete treatments, one "always treat" value per non-default treatment
+                for (idx, length) in [(0, 1), (1, 1), (2, 1), (3, 2)]:
+                    _, policy_val, always_trt = ca._policy_tree_output(X, inds[idx])
+                    assert isinstance(always_trt, list)
+                    assert np.array(policy_val).shape == ()
+                    assert np.array(always_trt).shape == (length,)
+
+                    # policy value should exceed always treating with any treatment
+                    assert_less_close(always_trt, policy_val)
 
                 if not classification:
                     # ExitStack can be used as a "do nothing" ContextManager
@@ -149,10 +165,8 @@ class TestCausalAnalysis(unittest.TestCase):
                 with cm:
                     inf = ca.whatif(X[:2], np.ones(shape=(2,)), inds[1], y[:2])
                     assert np.shape(inf.point_estimate) == np.shape(y[:2])
-                    inf.summary_frame()
                     inf = ca.whatif(X[:2], np.ones(shape=(2,)), inds[2], y[:2])
                     assert np.shape(inf.point_estimate) == np.shape(y[:2])
-                    inf.summary_frame()
 
                     ca._whatif_dict(X[:2], np.ones(shape=(2,)), inds[1], y[:2])
 
@@ -200,12 +214,19 @@ class TestCausalAnalysis(unittest.TestCase):
             loc_point_est = np.array(loc_dict[_CausalInsightsConstants.PointEstimateKey])
 
             ca._policy_tree_output(X, 1)
-            ca._heterogeneity_tree_string(X, 1)
-            ca._heterogeneity_tree_string(X, 3)
+            ca._heterogeneity_tree_output(X, 1)
+            ca._heterogeneity_tree_output(X, 3)
 
-            # Can't handle multi-dimensional treatments
-            with self.assertRaises(AssertionError):
-                ca._policy_tree_output(X, 3)
+            # Make sure we handle continuous, binary, and multi-class treatments
+            # For multiple discrete treatments, one "always treat" value per non-default treatment
+            for (idx, length) in [(0, 1), (1, 1), (2, 1), (3, 2)]:
+                _, policy_val, always_trt = ca._policy_tree_output(X, idx)
+                assert isinstance(always_trt, list)
+                assert np.array(policy_val).shape == ()
+                assert np.array(always_trt).shape == (length,)
+
+                # policy value should exceed always treating with any treatment
+                assert_less_close(always_trt, policy_val)
 
             # global shape is (d_y, sum(d_t))
             assert glo_point_est.shape == coh_point_est.shape == (1, 5)
@@ -217,11 +238,9 @@ class TestCausalAnalysis(unittest.TestCase):
                 cm = self.assertRaises(Exception)
             with cm:
                 inf = ca.whatif(X[:2], np.ones(shape=(2,)), 1, y[:2])
-                assert np.shape(inf.point_estimate) == np.shape(y[:2])
-                inf.summary_frame()
+                assert np.shape(inf.point_estimate) == (2,)
                 inf = ca.whatif(X[:2], np.ones(shape=(2,)), 2, y[:2])
-                assert np.shape(inf.point_estimate) == np.shape(y[:2])
-                inf.summary_frame()
+                assert np.shape(inf.point_estimate) == (2,)
 
                 ca._whatif_dict(X[:2], np.ones(shape=(2,)), 1, y[:2])
 
@@ -280,7 +299,7 @@ class TestCausalAnalysis(unittest.TestCase):
         assert loc_point_est.shape == (2,) + glo_point_est.shape
 
         ca._policy_tree_output(X, inds[0])
-        ca._heterogeneity_tree_string(X, inds[0])
+        ca._heterogeneity_tree_output(X, inds[0])
 
     def test_final_models(self):
         d_y = (1,)
@@ -303,12 +322,19 @@ class TestCausalAnalysis(unittest.TestCase):
                 loc_dict = ca._local_causal_effect_dict(X[:2])
 
                 ca._policy_tree_output(X, 1)
-                ca._heterogeneity_tree_string(X, 1)
-                ca._heterogeneity_tree_string(X, 3)
+                ca._heterogeneity_tree_output(X, 1)
+                ca._heterogeneity_tree_output(X, 3)
 
-                # Can't handle multi-dimensional treatments
-                with self.assertRaises(AssertionError):
-                    ca._policy_tree_output(X, 3)
+                # Make sure we handle continuous, binary, and multi-class treatments
+                # For multiple discrete treatments, one "always treat" value per non-default treatment
+                for (idx, length) in [(0, 1), (1, 1), (2, 1), (3, 2)]:
+                    _, policy_val, always_trt = ca._policy_tree_output(X, idx)
+                    assert isinstance(always_trt, list)
+                    assert np.array(policy_val).shape == ()
+                    assert np.array(always_trt).shape == (length,)
+
+                    # policy value should exceed always treating with any treatment
+                    assert_less_close(always_trt, policy_val)
 
                 if not classification:
                     # ExitStack can be used as a "do nothing" ContextManager
@@ -317,10 +343,7 @@ class TestCausalAnalysis(unittest.TestCase):
                     cm = self.assertRaises(Exception)
                 with cm:
                     inf = ca.whatif(X[:2], np.ones(shape=(2,)), 1, y[:2])
-                    inf.summary_frame()
                     inf = ca.whatif(X[:2], np.ones(shape=(2,)), 2, y[:2])
-                    inf.summary_frame()
-
                     ca._whatif_dict(X[:2], np.ones(shape=(2,)), 1, y[:2])
 
         with self.assertRaises(AssertionError):
@@ -371,12 +394,19 @@ class TestCausalAnalysis(unittest.TestCase):
         assert loc_point_est.shape == (2,) + glo_point_est.shape
 
         ca._policy_tree_output(X, inds[1])
-        ca._heterogeneity_tree_string(X, inds[1])
-        ca._heterogeneity_tree_string(X, inds[3])
+        ca._heterogeneity_tree_output(X, inds[1])
+        ca._heterogeneity_tree_output(X, inds[3])
 
-        # Can't handle multi-dimensional treatments
-        with self.assertRaises(AssertionError):
-            ca._policy_tree_output(X, inds[3])
+        # Make sure we handle continuous, binary, and multi-class treatments
+        # For multiple discrete treatments, one "always treat" value per non-default treatment
+        for (idx, length) in [(0, 1), (1, 1), (2, 1), (3, 2)]:
+            _, policy_val, always_trt = ca._policy_tree_output(X, inds[idx])
+            assert isinstance(always_trt, list)
+            assert np.array(policy_val).shape == ()
+            assert np.array(always_trt).shape == (length,)
+
+            # policy value should exceed always treating with any treatment
+            assert_less_close(always_trt, policy_val)
 
     def test_warm_start(self):
         for classification in [True, False]:
@@ -481,3 +511,86 @@ class TestCausalAnalysis(unittest.TestCase):
 
         # column d is now okay, too
         self.assertEqual([res.feature_name for res in ca._results], ['a', 'b', 'c', 'd', 'f', 'g', 'h'])
+
+    def test_individualized_policy(self):
+        y = pd.Series(np.random.choice([0, 1], size=(500,)))
+        X = pd.DataFrame({'a': np.random.normal(size=500),
+                          'b': np.random.normal(size=500),
+                          'c': np.random.choice([0, 1], size=500),
+                          'd': np.random.choice(['a', 'b', 'c'], size=500)})
+        inds = ['a', 'b', 'c', 'd']
+        cats = ['c', 'd']
+        hinds = ['a', 'd']
+
+        ca = CausalAnalysis(inds, cats, hinds, heterogeneity_model='linear')
+        ca.fit(X, y)
+        df = ca.individualized_policy(X, 'a')
+        self.assertEqual(df.shape[0], 500)  # all rows included by default
+        self.assertEqual(df.shape[1], 4 + X.shape[1])  # new cols for policy, effect, upper and lower bounds
+        df = ca.individualized_policy(X, 'b', n_rows=5)
+        self.assertEqual(df.shape[0], 5)
+        self.assertEqual(df.shape[1], 4 + X.shape[1])  # new cols for policy, effect, upper and lower bounds
+        # verify that we can use a scalar treatment cost
+        df = ca.individualized_policy(X, 'c', treatment_costs=100)
+        self.assertEqual(df.shape[0], 500)
+        self.assertEqual(df.shape[1], 4 + X.shape[1])  # new cols for policy, effect, upper and lower bounds
+        # verify that we can specify per-treatment costs for each sample
+        df = ca.individualized_policy(X, 'd', alpha=0.05, treatment_costs=np.random.normal(size=(500, 2)))
+        self.assertEqual(df.shape[0], 500)
+        self.assertEqual(df.shape[1], 4 + X.shape[1])  # new cols for policy, effect, upper and lower bounds
+
+        dictionary = ca._individualized_policy_dict(X, 'a')
+
+    def test_random_state(self):
+        # verify that using the same state returns the same results each time
+        y = np.random.choice([0, 1], size=(500,))
+        X = np.hstack((np.random.normal(size=(500, 2)),
+                       np.random.choice([0, 1], size=(500, 1)),
+                       np.random.choice([0, 1, 2], size=(500, 1))))
+        inds = [0, 1, 2, 3]
+        cats = [2, 3]
+        hinds = [0, 3]
+        for n_model in ['linear', 'automl']:
+            for h_model in ['linear', 'forest']:
+                for classification in [True, False]:
+                    ca = CausalAnalysis(inds, cats, hinds, classification=classification,
+                                        nuisance_models=n_model, heterogeneity_model=h_model, random_state=123)
+                    ca.fit(X, y)
+                    glo = ca.global_causal_effect()
+
+                    ca2 = CausalAnalysis(inds, cats, hinds, classification=classification,
+                                         nuisance_models=n_model, heterogeneity_model=h_model, random_state=123)
+                    ca2.fit(X, y)
+                    glo2 = ca.global_causal_effect()
+
+                    np.testing.assert_equal(glo.point.values, glo2.point.values)
+                    np.testing.assert_equal(glo.stderr.values, glo2.stderr.values)
+
+    def test_can_set_categories(self):
+        y = pd.Series(np.random.choice([0, 1], size=(500,)))
+        X = pd.DataFrame({'a': np.random.normal(size=500),
+                          'b': np.random.normal(size=500),
+                          'c': np.random.choice([0, 1], size=500),
+                          'd': np.random.choice(['a', 'b', 'c'], size=500)})
+        inds = ['a', 'b', 'c', 'd']
+        cats = ['c', 'd']
+        hinds = ['a', 'd']
+
+        # set the categories for column 'd' explicitly so that b is default
+        categories = ['auto', ['b', 'c', 'a']]
+
+        ca = CausalAnalysis(inds, cats, hinds, heterogeneity_model='linear', categories=categories)
+        ca.fit(X, y)
+        eff = ca.global_causal_effect()
+        values = eff.loc['d'].index.values
+        np.testing.assert_equal(eff.loc['d'].index.values, ['cvb', 'avb'])
+
+    def test_policy_with_index(self):
+        inds = np.arange(1000)
+        np.random.shuffle(inds)
+        X = pd.DataFrame(np.random.normal(0, 1, size=(1000, 2)), columns=['A', 'B'], index=inds)
+        y = np.random.normal(0, 1, size=1000)
+        ca_test = CausalAnalysis(feature_inds=['A'], categorical=[])
+        ca_test.fit(X, y)
+        ind_policy = ca_test.individualized_policy(X[:50], feature_index='A')
+        self.assertFalse(ind_policy.isnull().values.any())

--- a/econml/tests/test_causal_analysis.py
+++ b/econml/tests/test_causal_analysis.py
@@ -450,10 +450,12 @@ class TestCausalAnalysis(unittest.TestCase):
                 categorical = [5, 6]
                 ca = CausalAnalysis(feat_inds, categorical, heterogeneity_inds=hetero_inds,
                                     classification=classification,
-                                    nuisance_models='linear', heterogeneity_model="linear", n_jobs=-1)
+                                    nuisance_models='linear', heterogeneity_model=h_model, n_jobs=-1)
                 ca.fit(X_df, y)
                 eff = ca.global_causal_effect(alpha=0.05)
                 eff = ca.local_causal_effect(X_df, alpha=0.05)
+                for ind in feat_inds:
+                    tree, val, always_trt = ca._policy_tree_output(X_df, ind)
 
     def test_can_serialize(self):
         import pickle

--- a/econml/tests/test_inference.py
+++ b/econml/tests/test_inference.py
@@ -414,7 +414,7 @@ class TestInference(unittest.TestCase):
         new_coef = est.coef_
         np.testing.assert_array_equal(coef, new_coef)
 
-    def test_translte(self):
+    def test_translate(self):
         Y, T, X, W = TestInference.Y, TestInference.T, TestInference.X, TestInference.W
         for offset in [10, pd.Series(np.arange(TestInference.X.shape[0]))]:
             for inf in ['auto', BootstrapInference(n_bootstrap_samples=5)]:
@@ -426,6 +426,19 @@ class TestInference(unittest.TestCase):
                 np.testing.assert_array_equal(pred + offset, pred2)
                 np.testing.assert_array_almost_equal(bounds[0] + offset, bounds2[0])
                 np.testing.assert_array_almost_equal(bounds[1] + offset, bounds2[1])
+
+    def test_scale(self):
+        Y, T, X, W = TestInference.Y, TestInference.T, TestInference.X, TestInference.W
+        for factor in [10, pd.Series(np.arange(TestInference.X.shape[0]))]:
+            for inf in ['auto', BootstrapInference(n_bootstrap_samples=5)]:
+                est = LinearDML().fit(Y, T, X=X, W=W, inference=inf)
+                inf = est.const_marginal_effect_inference(X)
+                pred, bounds, summary = inf.point_estimate, inf.conf_int(), inf.summary_frame()
+                inf.scale(factor)
+                pred2, bounds2, summary2 = inf.point_estimate, inf.conf_int(), inf.summary_frame()
+                np.testing.assert_array_equal(pred * factor, pred2)
+                np.testing.assert_array_almost_equal(bounds[0] * factor, bounds2[0])
+                np.testing.assert_array_almost_equal(bounds[1] * factor, bounds2[1])
 
     class _NoFeatNamesEst:
         def __init__(self, cate_est):

--- a/econml/tree/_tree_classes.py
+++ b/econml/tree/_tree_classes.py
@@ -187,8 +187,8 @@ class BaseTree(BaseEstimator):
             raise ValueError("min_weight_fraction_leaf must in [0, 0.5]")
         if max_depth < 0:
             raise ValueError("max_depth must be greater than or equal to zero. ")
-        if not (0 < max_features <= self.n_features_):
-            raise ValueError("max_features must be in (0, n_features]")
+        if not (0 <= max_features <= self.n_features_):
+            raise ValueError("max_features must be in [0, n_features]")
         if not 0 <= self.min_balancedness_tol <= 0.5:
             raise ValueError("min_balancedness_tol must be in [0, 0.5]")
 
@@ -278,7 +278,7 @@ class BaseTree(BaseEstimator):
         """Validate X whenever one tries to predict, apply, or any other of the prediction
         related methods. """
         if check_input:
-            X = check_array(X, dtype=DTYPE, accept_sparse=False)
+            X = check_array(X, dtype=DTYPE, accept_sparse=False, ensure_min_features=0)
 
         n_features = X.shape[1]
         if self.n_features_ != n_features:

--- a/notebooks/Solutions/Causal Interpretation for Boston Housing Price.ipynb
+++ b/notebooks/Solutions/Causal Interpretation for Boston Housing Price.ipynb
@@ -915,7 +915,7 @@
    "source": [
     "print(\"current average housing price on test set: \", y_test.mean())\n",
     "cf = ca.whatif(x_test, x_test[:, 5] + 1, 5, y_test)\n",
-    "cf.population_summary()"
+    "cf"
    ]
   },
   {


### PR DESCRIPTION
This makes a few changes:
* Makes `whatif` return a dataframe to harmonize with the other methods
* Supports exporting trees as dictionaries
* Removes policy treatment values; returns always treat and policy values instead
* Adds an `individualized_policy` method (and dictionary counterpart) 