### PR TITLE
Make graphviz a soft dependency

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ jobs:
   parameters:
     versions: ['3.8']
     images: ['ubuntu-18.04']
-    package: '-e .[tf]'
+    package: '-e .[tf, plt]'
     job:
       job: 'Notebooks'
       dependsOn: 'EvalChanges'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ jobs:
   parameters:
     versions: ['3.8']
     images: ['ubuntu-18.04']
-    package: '-e .[tf, plt]'
+    package: '-e .[tf,plt]'
     job:
       job: 'Notebooks'
       dependsOn: 'EvalChanges'

--- a/econml/_tree_exporter.py
+++ b/econml/_tree_exporter.py
@@ -13,7 +13,6 @@ import abc
 import numpy as np
 import re
 from io import StringIO
-import graphviz
 from sklearn.utils.validation import check_is_fitted
 
 try:
@@ -28,6 +27,15 @@ except ImportError as exn:
                                      "install econml[plt] or econml[all] to require it, or install matplotlib "
                                      "separately, to use the tree interpreters", exn)
 
+try:
+    import graphviz
+except ImportError as exn:
+    from .utilities import MissingModule
+
+    # make any access to graphviz or plt throw an exception
+    graphviz = plt = MissingModule("graphviz is no longer a dependency of the main econml package; "
+                                   "install econml[plt] or econml[all] to require it, or install graphviz "
+                                   "separately, to use the tree interpreters", exn)
 
 # HACK: We're relying on some of sklearn's non-public classes which are not completely stable.
 #       However, the alternative is reimplementing a bunch of intricate stuff by hand

--- a/econml/_tree_exporter.py
+++ b/econml/_tree_exporter.py
@@ -33,9 +33,9 @@ except ImportError as exn:
     from .utilities import MissingModule
 
     # make any access to graphviz or plt throw an exception
-    graphviz = plt = MissingModule("graphviz is no longer a dependency of the main econml package; "
-                                   "install econml[plt] or econml[all] to require it, or install graphviz "
-                                   "separately, to use the tree interpreters", exn)
+    graphviz = MissingModule("graphviz is no longer a dependency of the main econml package; "
+                             "install econml[plt] or econml[all] to require it, or install graphviz "
+                             "separately, to use the tree interpreters", exn)
 
 # HACK: We're relying on some of sklearn's non-public classes which are not completely stable.
 #       However, the alternative is reimplementing a bunch of intricate stuff by hand

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ install_requires =
     joblib >= 0.13.0
     numba != 0.42.1
     statsmodels >= 0.10
-    graphviz
     pandas
     shap ~= 0.38.1
     dowhy
@@ -65,6 +64,7 @@ tf =
     keras < 2.4
     tensorflow > 1.10, < 2.3
 plt =
+    graphviz
     matplotlib
 all =
     azure-cli


### PR DESCRIPTION
Makes graphviz a soft dependency and part of the `plt` extra. Export to graphviz is not essential causal functionality.