### PR TITLE
Several small fixes

### DIFF
--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -6,7 +6,7 @@
 parameters:
   package: '-e .'
   images: ['ubuntu-18.04', 'macOS-10.15', 'windows-2019']
-  versions: ['3.6', '3.7', '3.8', '3.9']
+  versions: ['3.7', '3.8', '3.9']
   job: 
     job: Job
   

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -59,7 +59,7 @@ jobs:
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
   # Install the package
-  - script: 'python -m pip install --upgrade pip && pip install --upgrade setuptools wheel Cython && pip install ${{ parameters.package }}'
+  - script: 'python -m pip install --upgrade pip && pip install --upgrade setuptools wheel Cython && pip install ${{ parameters.package }} && pip freeze --exclude-editable'
     displayName: 'Install dependencies'
 
   - ${{ parameters.job.steps }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
 
 - template: azure-pipelines-steps.yml
   parameters:
-    versions: ['3.6']
+    versions: ['3.8']
     images: ['ubuntu-18.04']
     package: '-e .[all]'
     job:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -89,7 +89,7 @@ root_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -219,7 +219,7 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'sklearn': ('https://scikit-learn.org/stable/', None),
                        'matplotlib': ('https://matplotlib.org/', None),
                        'shap': ('https://shap.readthedocs.io/en/stable/', None),
-                       'dowhy': ('https://microsoft.github.io/dowhy/', None)}
+                       'dowhy': ('https://py-why.github.io/dowhy/', None)}
 
 
 # -- Options for todo extension ----------------------------------------------

--- a/doc/spec/estimation/dml.rst
+++ b/doc/spec/estimation/dml.rst
@@ -553,8 +553,8 @@ Usage FAQs
         from econml.dml import DML
         from sklearn.linear_model import ElasticNetCV
         from sklearn.ensemble import RandomForestRegressor
-        est = DML(model_y=RandomForestRegressor(oob_score=True),
-                  model_t=RandomForestRegressor(oob_score=True),
+        est = DML(model_y=RandomForestRegressor(),
+                  model_t=RandomForestRegressor(),
                   model_final=ElasticNetCV(fit_intercept=False), featurizer=PolynomialFeatures(degree=1))
         est.fit(y, T, X=X, W=W)
         est.score_

--- a/econml/sklearn_extensions/linear_model.py
+++ b/econml/sklearn_extensions/linear_model.py
@@ -105,7 +105,7 @@ class WeightedModelMixin:
             X, y, X_offset, y_offset, X_scale = self._preprocess_data(
                 X, y, fit_intercept=self.fit_intercept, normalize=False,
                 copy=self.copy_X, check_input=check_input if check_input is not None else True,
-                sample_weight=sample_weight, return_mean=True)
+                sample_weight=sample_weight)
             # Weight inputs
             normalized_weights = X.shape[0] * sample_weight / np.sum(sample_weight)
             sqrt_weights = np.sqrt(normalized_weights)
@@ -207,7 +207,7 @@ class WeightedLasso(WeightedModelMixin, Lasso):
                  random_state=None, selection='cyclic'):
         super().__init__(
             alpha=alpha, fit_intercept=fit_intercept,
-            normalize=False, precompute=precompute, copy_X=copy_X,
+            precompute=precompute, copy_X=copy_X,
             max_iter=max_iter, tol=tol, warm_start=warm_start,
             positive=positive, random_state=random_state,
             selection=selection)
@@ -297,11 +297,11 @@ class WeightedMultiTaskLasso(WeightedModelMixin, MultiTaskLasso):
 
     """
 
-    def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
+    def __init__(self, alpha=1.0, fit_intercept=True,
                  copy_X=True, max_iter=1000, tol=1e-4, warm_start=False,
                  random_state=None, selection='cyclic'):
         super().__init__(
-            alpha=alpha, fit_intercept=fit_intercept, normalize=False,
+            alpha=alpha, fit_intercept=fit_intercept,
             copy_X=copy_X, max_iter=max_iter, tol=tol, warm_start=warm_start,
             random_state=random_state, selection=selection)
 
@@ -407,13 +407,13 @@ class WeightedLassoCV(WeightedModelMixin, LassoCV):
     """
 
     def __init__(self, eps=1e-3, n_alphas=100, alphas=None, fit_intercept=True,
-                 precompute='auto', max_iter=1000, tol=1e-4, normalize=False,
+                 precompute='auto', max_iter=1000, tol=1e-4,
                  copy_X=True, cv=None, verbose=False, n_jobs=None,
                  positive=False, random_state=None, selection='cyclic'):
 
         super().__init__(
             eps=eps, n_alphas=n_alphas, alphas=alphas,
-            fit_intercept=fit_intercept, normalize=False,
+            fit_intercept=fit_intercept,
             precompute=precompute, max_iter=max_iter, tol=tol, copy_X=copy_X,
             cv=cv, verbose=verbose, n_jobs=n_jobs, positive=positive,
             random_state=random_state, selection=selection)
@@ -518,13 +518,13 @@ class WeightedMultiTaskLassoCV(WeightedModelMixin, MultiTaskLassoCV):
     """
 
     def __init__(self, eps=1e-3, n_alphas=100, alphas=None, fit_intercept=True,
-                 normalize=False, max_iter=1000, tol=1e-4,
+                 max_iter=1000, tol=1e-4,
                  copy_X=True, cv=None, verbose=False, n_jobs=None,
                  random_state=None, selection='cyclic'):
 
         super().__init__(
             eps=eps, n_alphas=n_alphas, alphas=alphas,
-            fit_intercept=fit_intercept, normalize=False,
+            fit_intercept=fit_intercept,
             max_iter=max_iter, tol=tol, copy_X=copy_X,
             cv=cv, verbose=verbose, n_jobs=n_jobs,
             random_state=random_state, selection=selection)
@@ -733,7 +733,7 @@ class DebiasedLasso(WeightedLasso):
         # Center X, y
         X, y, X_offset, y_offset, X_scale = self._preprocess_data(
             X, y, fit_intercept=self.fit_intercept, normalize=False,
-            copy=self.copy_X, check_input=check_input, sample_weight=sample_weight, return_mean=True)
+            copy=self.copy_X, check_input=check_input, sample_weight=sample_weight)
 
         # Calculate quantities that will be used later on. Account for centered data
         y_pred = self.predict(X) - self.intercept_

--- a/econml/tests/test_dml.py
+++ b/econml/tests/test_dml.py
@@ -1143,13 +1143,13 @@ class TestDML(unittest.TestCase):
         # test nested grouping
         class NestedModel(LassoCV):
             def __init__(self, eps=1e-3, n_alphas=100, alphas=None, fit_intercept=True,
-                         precompute='auto', max_iter=1000, tol=1e-4, normalize=False,
+                         precompute='auto', max_iter=1000, tol=1e-4,
                          copy_X=True, cv=None, verbose=False, n_jobs=None,
                          positive=False, random_state=None, selection='cyclic'):
 
                 super().__init__(
                     eps=eps, n_alphas=n_alphas, alphas=alphas,
-                    fit_intercept=fit_intercept, normalize=normalize,
+                    fit_intercept=fit_intercept,
                     precompute=precompute, max_iter=max_iter, tol=tol, copy_X=copy_X,
                     cv=cv, verbose=verbose, n_jobs=n_jobs, positive=positive,
                     random_state=random_state, selection=selection)

--- a/econml/tests/test_drlearner.py
+++ b/econml/tests/test_drlearner.py
@@ -801,13 +801,13 @@ class TestDRLearner(unittest.TestCase):
         # test nested grouping
         class NestedModel(LassoCV):
             def __init__(self, eps=1e-3, n_alphas=100, alphas=None, fit_intercept=True,
-                         precompute='auto', max_iter=1000, tol=1e-4, normalize=False,
+                         precompute='auto', max_iter=1000, tol=1e-4,
                          copy_X=True, cv=None, verbose=False, n_jobs=None,
                          positive=False, random_state=None, selection='cyclic'):
 
                 super().__init__(
                     eps=eps, n_alphas=n_alphas, alphas=alphas,
-                    fit_intercept=fit_intercept, normalize=normalize,
+                    fit_intercept=fit_intercept,
                     precompute=precompute, max_iter=max_iter, tol=tol, copy_X=copy_X,
                     cv=cv, verbose=verbose, n_jobs=n_jobs, positive=positive,
                     random_state=random_state, selection=selection)

--- a/notebooks/CustomerScenarios/Case Study - Recommendation AB Testing at An Online Travel Company - EconML + DoWhy.ipynb
+++ b/notebooks/CustomerScenarios/Case Study - Recommendation AB Testing at An Online Travel Company - EconML + DoWhy.ipynb
@@ -1066,7 +1066,7 @@
     }
    ],
    "source": [
-    "res_random = est_dw.refute_estimate(method_name=\"random_common_cause\", num_simulations=10)\n",
+    "res_random = est_dw.refute_estimate(method_name=\"random_common_cause\", num_simulations=5)\n",
     "print(res_random)"
    ]
   },

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,8 @@ tf =
     ; This extra is not currently compatible with python 3.9 or above because of tensorflow breaking changes
     keras < 2.4;python_version < '3.9'
     tensorflow > 1.10, < 2.3;python_version < '3.9'
+    ; Version capped due to tensorflow incompatibility
+    protobuf < 4
 plt =
     graphviz
     matplotlib
@@ -64,6 +66,8 @@ all =
     azure-cli
     keras < 2.4
     tensorflow > 1.10, < 2.3
+    ; Version capped due to tensorflow incompatibility
+    protobuf < 4
     matplotlib
     
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ project_urls =
     Source Code=https://github.com/Microsoft/EconML
     Documentation=https://econml.azurewebsites.net/
 classifiers =
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
This PR makes a few small changes

* Reduce number of simulations in dowhy refutation to prevent notebook test timeouts
* Changes our sklearn-based linear models to remove all use of the `normalize` init arg (deprecated in sklearn 1.0, removed in sklearn 1.2)
*  Cap protobuf versions to work around tensorflow compat issue (https://github.com/protocolbuffers/protobuf/issues/10051)
*  Removes Python 3.6 support (EOL was last December and several dependencies have already dropped support)
*  Enables using Sphinx >= 5.0 for documentation generation
*  Updates the dowhy documentation links to point to their new py-why address