### PR TITLE
Remove dowhy as core dependency

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
   parameters:
     versions: ['3.8']
     images: ['ubuntu-18.04']
-    package: '-e .[tf,plt]'
+    package: '-e .[tf,plt,dowhy]'
     job:
       job: 'Notebooks_cust'
       dependsOn: 'EvalChanges'
@@ -192,7 +192,7 @@ jobs:
 
 - template: azure-pipelines-steps.yml
   parameters:
-    package: '-e .[tf,plt]'
+    package: '-e .[tf,plt,dowhy]'
     job:
       job: Tests_main
       dependsOn: 'EvalChanges'

--- a/econml/dowhy.py
+++ b/econml/dowhy.py
@@ -14,8 +14,14 @@ import inspect
 import pandas as pd
 import numpy as np
 import warnings
-from dowhy import CausalModel
-from econml.utilities import check_input_arrays, reshape_arrays_2dim, get_input_columns
+from econml.utilities import check_input_arrays, reshape_arrays_2dim, get_input_columns, MissingModule
+try:
+    import dowhy
+    from dowhy import CausalModel
+except ImportError as exn:
+    dowhy = CausalModel = MissingModule("dowhy is no longer a dependency of the main econml "
+                                        "package; install econml[dowhy] or econml[all] to require it, or install "
+                                        "dowhy separately to use dowhy from econml", exn)
 
 
 class DoWhyWrapper:
@@ -30,6 +36,9 @@ class DoWhyWrapper:
     """
 
     def __init__(self, cate_estimator):
+        from pkg_resources import parse_version
+        if parse_version(dowhy.__version__) >= parse_version('0.9'):
+            warnings.warn("econml has not been tested with dowhy versions >= 0.9")
         self._cate_estimator = cate_estimator
 
     def _get_params(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ install_requires =
     statsmodels >= 0.10
     pandas
     shap >= 0.38.1, < 0.41.0
-    dowhy < 0.8
     lightgbm
 test_suite = econml.tests
 tests_require =
@@ -62,6 +61,8 @@ tf =
 plt =
     graphviz
     matplotlib
+dowhy = 
+    dowhy < 0.9
 all =
     azure-cli
     keras < 2.4
@@ -69,6 +70,7 @@ all =
     ; Version capped due to tensorflow incompatibility
     protobuf < 4
     matplotlib
+    dowhy < 0.9
     
 [options.packages.find]
 include =


### PR DESCRIPTION
This removes dowhy as a core dependency, adding it to a new [dowhy] extra. If the user does not have dowhy installed but tries to use the DoWhyWrapper, we will give them an error message directing them to install it, and if they are using a more recent version of dowhy than our last-known-good, we'll warn them.