### PR TITLE
update some pipeline images (macos-12, ubuntu20), fix pycodestyle E275

### DIFF
--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -5,7 +5,7 @@
 
 parameters:
   package: '-e .'
-  images: ['ubuntu-18.04', 'macOS-10.15', 'windows-2019']
+  images: ['ubuntu-18.04', 'macOS-12', 'windows-2019']
   versions: ['3.6', '3.7', '3.8', '3.9']
   job: 
     job: Job

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -5,7 +5,7 @@
 
 parameters:
   package: '-e .'
-  images: ['ubuntu-18.04', 'macOS-12', 'windows-2019']
+  images: ['ubuntu-20.04', 'macOS-12', 'windows-2019']
   versions: ['3.6', '3.7', '3.8', '3.9']
   job: 
     job: Job

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
 - job: 'EvalChanges'
   displayName: 'Analyze changed files to determine which job to run'
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macos-12'
   steps:
   # We want to enforce the following rules for PRs:
   # * if all modifications are to README.md
@@ -180,7 +180,7 @@ jobs:
 - template: azure-pipelines-steps.yml
   parameters:
     versions: ['3.8']
-    images: ['macOS-10.15']
+    images: ['macos-12']
     job:
       job: 'Linting'
       dependsOn: 'EvalChanges'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
 - template: azure-pipelines-steps.yml
   parameters:
     versions: ['3.8']
-    images: ['ubuntu-18.04']
+    images: ['ubuntu-20.04']
     package: '-e .[all]'
     job:
       job: 'Docs'
@@ -88,7 +88,7 @@ jobs:
 - template: azure-pipelines-steps.yml
   parameters:
     versions: ['3.8']
-    images: ['ubuntu-18.04']
+    images: ['ubuntu-20.04']
     package: '-e .[tf,plt]'
     job:
       job: 'Notebooks_cust'
@@ -116,7 +116,7 @@ jobs:
 - template: azure-pipelines-steps.yml
   parameters:
     versions: ['3.8']
-    images: ['ubuntu-18.04']
+    images: ['ubuntu-20.04']
     package: '-e .[tf,plt]'
     job:
       job: 'Notebooks_noncust'
@@ -148,7 +148,7 @@ jobs:
 #   variables:
 #     python.version: '3.6'
 #   pool:
-#     vmImage: 'ubuntu-18.04'
+#     vmImage: 'ubuntu-20.04'
 #   steps:
 #   - template: azure-pipelines-steps.yml
 #     parameters:
@@ -247,7 +247,7 @@ jobs:
 - template: azure-pipelines-steps.yml
   parameters:
     # exclude macOS since these tests frequently break there
-    images: ['ubuntu-18.04', 'windows-2019']
+    images: ['ubuntu-20.04', 'windows-2019']
     package: '-e .[tf,plt]'
     job:
       job: Tests_serial

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -219,7 +219,7 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'sklearn': ('https://scikit-learn.org/stable/', None),
                        'matplotlib': ('https://matplotlib.org/', None),
                        'shap': ('https://shap.readthedocs.io/en/stable/', None),
-                       'dowhy': ('https://py-why.github.io/dowhy/', None)}
+                       'dowhy': ('https://py-why.github.io/dowhy/v0.8/', None)}
 
 
 # -- Options for todo extension ----------------------------------------------

--- a/econml/automated_ml/_automated_ml.py
+++ b/econml/automated_ml/_automated_ml.py
@@ -85,8 +85,8 @@ def setAutomatedMLWorkspace(create_workspace=False,
         ws.write_config()
         print("Workspace configuration has succeeded.")
     except ProjectSystemException:
-        if(create_workspace):
-            if(create_resource_group):
+        if (create_workspace):
+            if (create_resource_group):
                 print("Workspace not accessible. Creating a new workspace and \
                 resource group.")
                 ws = Workspace.create(name=workspace_name,
@@ -351,9 +351,9 @@ class EconAutoMLConfig(AutoMLConfig):
             whitelist_models = list(LINEAR_MODELS_SET.intersection(SAMPLE_WEIGHTS_MODELS_SET))
 
         else:
-            if(linear_model_required):
+            if (linear_model_required):
                 whitelist_models = list(LINEAR_MODELS_SET)
-            if(sample_weights_required):
+            if (sample_weights_required):
                 whitelist_models = list(SAMPLE_WEIGHTS_MODELS_SET)
 
         kwargs['whitelist_models'] = whitelist_models

--- a/econml/iv/nnet/_deepiv.py
+++ b/econml/iv/nnet/_deepiv.py
@@ -208,7 +208,7 @@ def response_loss_model(h, p, d_z, d_x, d_y, samples=1, use_upper_bound=False, g
     A Keras model that takes as inputs z, x, and y and generates a single output containing the loss.
 
     """
-    assert not(use_upper_bound and gradient_samples)
+    assert not (use_upper_bound and gradient_samples)
 
     # sample: (() -> Layer, int) -> Layer
     def sample(f, n):

--- a/econml/tests/test_dml.py
+++ b/econml/tests/test_dml.py
@@ -91,7 +91,7 @@ class TestDML(unittest.TestCase):
                                 # since T isn't passed to const_marginal_effect, defaults to one row if X is None
                                 const_marginal_effect_shape = ((n if d_x else 1,) +
                                                                ((d_y,) if d_y > 0 else ()) +
-                                                               ((d_t_final,) if d_t_final > 0 else()))
+                                                               ((d_t_final,) if d_t_final > 0 else ()))
                                 const_marginal_effect_summaryframe_shape = (
                                     (n if d_x else 1) * (d_y if d_y > 0 else 1) *
                                     (d_t_final if d_t_final > 0 else 1), 6)
@@ -159,7 +159,7 @@ class TestDML(unittest.TestCase):
                                       True,
                                       ['auto', 'blb'])]:
 
-                                    if not(multi) and d_y > 1:
+                                    if not (multi) and d_y > 1:
                                         continue
 
                                     if X is None and isinstance(est, CausalForestDML):
@@ -326,7 +326,7 @@ class TestDML(unittest.TestCase):
 
                                             if isinstance(est, CausalForestDML):
                                                 np.testing.assert_array_equal(est.feature_importances_.shape,
-                                                                              ((d_y,) if d_y > 0 else()) + fd_x)
+                                                                              ((d_y,) if d_y > 0 else ()) + fd_x)
 
                                             # make sure we can call effect with implied scalar treatments,
                                             # no matter the dimensions of T, and also that we warn when there
@@ -337,7 +337,7 @@ class TestDML(unittest.TestCase):
                                                 # ExitStack can be used as a "do nothing" ContextManager
                                                 cm = ExitStack()
                                             with cm:
-                                                effect_shape2 = (n if d_x else 1,) + ((d_y,) if d_y > 0 else())
+                                                effect_shape2 = (n if d_x else 1,) + ((d_y,) if d_y > 0 else ())
                                                 eff = est.effect(X) if not is_discrete else est.effect(
                                                     X, T0='a', T1='b')
                                                 self.assertEqual(shape(eff), effect_shape2)
@@ -383,7 +383,7 @@ class TestDML(unittest.TestCase):
                             # since T isn't passed to const_marginal_effect, defaults to one row if X is None
                             const_marginal_effect_shape = ((n if d_x else 1,) +
                                                            ((d_y,) if d_y > 0 else ()) +
-                                                           ((d_t_final,) if d_t_final > 0 else()))
+                                                           ((d_t_final,) if d_t_final > 0 else ()))
                             const_marginal_effect_summaryframe_shape = (
                                 (n if d_x else 1) * (d_y if d_y > 0 else 1) * (d_t_final if d_t_final > 0 else 1), 6)
 
@@ -405,7 +405,7 @@ class TestDML(unittest.TestCase):
                                                       True,
                                                       base_infs), ]:
 
-                                if not(multi) and d_y > 1:
+                                if not (multi) and d_y > 1:
                                     continue
 
                                 for inf in infs:
@@ -512,7 +512,7 @@ class TestDML(unittest.TestCase):
                                         else:
                                             cm = ExitStack()  # ExitStack can be used as a "do nothing" ContextManager
                                         with cm:
-                                            effect_shape2 = (n if d_x else 1,) + ((d_y,) if d_y > 0 else())
+                                            effect_shape2 = (n if d_x else 1,) + ((d_y,) if d_y > 0 else ())
                                             eff = est.effect(X) if not is_discrete else est.effect(X, T0='a', T1='b')
                                             self.assertEqual(shape(eff), effect_shape2)
 

--- a/econml/tests/test_drlearner.py
+++ b/econml/tests/test_drlearner.py
@@ -100,7 +100,7 @@ class TestDRLearner(unittest.TestCase):
                         # since T isn't passed to const_marginal_effect, defaults to one row if X is None
                         const_marginal_effect_shape = ((n if d_x else 1,) +
                                                        ((d_y,) if d_y > 0 else ()) +
-                                                       ((d_t_final,) if d_t_final > 0 else()))
+                                                       ((d_t_final,) if d_t_final > 0 else ()))
                         const_marginal_effect_summaryframe_shape = (
                             (n if d_x else 1) * (d_y if d_y > 0 else 1) * (d_t_final if d_t_final > 0 else 1), 6)
 
@@ -261,7 +261,7 @@ class TestDRLearner(unittest.TestCase):
                                         cm = ExitStack()  # ExitStack can be used as a "do nothing" ContextManager
                                     with cm:
                                         effect_shape2 = (
-                                            n if d_x else 1,) + ((d_y,) if d_y > 0 else())
+                                            n if d_x else 1,) + ((d_y,) if d_y > 0 else ())
                                         eff = est.effect(X, T0='a', T1='b')
                                         self.assertEqual(
                                             shape(eff), effect_shape2)

--- a/econml/tests/test_dynamic_dml.py
+++ b/econml/tests/test_dynamic_dml.py
@@ -65,7 +65,7 @@ class TestDynamicDML(unittest.TestCase):
                                 # since T isn't passed to const_marginal_effect, defaults to one row if X is None
                                 const_marginal_effect_shape = ((n if d_x else 1,) +
                                                                ((d_y,) if d_y > 0 else ()) +
-                                                               ((d_t_final,) if d_t_final > 0 else()))
+                                                               ((d_t_final,) if d_t_final > 0 else ()))
                                 const_marginal_effect_summaryframe_shape = (
                                     (n if d_x else 1) * (d_y if d_y > 0 else 1) *
                                     (d_t_final if d_t_final > 0 else 1), 6)
@@ -247,7 +247,7 @@ class TestDynamicDML(unittest.TestCase):
                                             # ExitStack can be used as a "do nothing" ContextManager
                                             cm = ExitStack()
                                         with cm:
-                                            effect_shape2 = (n if d_x else 1,) + ((d_y,) if d_y > 0 else())
+                                            effect_shape2 = (n if d_x else 1,) + ((d_y,) if d_y > 0 else ())
                                             eff = est.effect(X) if not is_discrete else est.effect(
                                                 X, T0='a', T1='b')
                                             self.assertEqual(shape(eff), effect_shape2)

--- a/econml/tests/test_two_stage_least_squares.py
+++ b/econml/tests/test_two_stage_least_squares.py
@@ -31,13 +31,13 @@ class Test2SLS(unittest.TestCase):
         # first polynomials are 1, x, x*x-1, x*x*x-3*x
         ones = np.ones(shape(inputs))
         polys = np.hstack([ones, inputs, inputs * inputs - ones, inputs * inputs * inputs - 3 * inputs])
-        assert(np.allclose(hf, polys * np.exp(-inputs * inputs / 2)))
+        assert (np.allclose(hf, polys * np.exp(-inputs * inputs / 2)))
 
         for j in [True, False]:
             hf = HermiteFeatures(1, shift=1, joint=j).fit_transform(inputs)
             # first derivatives are -x, -x^2+1 (since there's just one column, joint-ness doesn't matter)
             polys = np.hstack([-inputs, -inputs * inputs + ones])
-            assert(np.allclose(hf, reshape(polys * np.exp(-inputs * inputs / 2), (5, 1, 2))))
+            assert (np.allclose(hf, reshape(polys * np.exp(-inputs * inputs / 2), (5, 1, 2))))
 
     @pytest.mark.slow
     def test_hermite_approx(self):
@@ -87,7 +87,7 @@ class Test2SLS(unittest.TestCase):
                             effect_shape = (n,) + ((d_y,) if d_y > 0 else ())
                             marginal_effect_shape = ((n if d_x else 1,) +
                                                      ((d_y,) if d_y > 0 else ()) +
-                                                     ((d_t,) if d_t > 0 else()))
+                                                     ((d_t,) if d_t > 0 else ()))
 
                             self.assertEqual(shape(marg_eff), marginal_effect_shape)
                             self.assertEqual(shape(eff), effect_shape)

--- a/econml/utilities.py
+++ b/econml/utilities.py
@@ -453,10 +453,10 @@ def reshape_Y_T(Y, T):
         Reshaped treatment policy.
 
     """
-    assert(len(Y) == len(T))
-    assert(Y.ndim <= 2)
+    assert (len(Y) == len(T))
+    assert (Y.ndim <= 2)
     if Y.ndim == 2:
-        assert(Y.shape[1] == 1)
+        assert (Y.shape[1] == 1)
         Y = Y.flatten()
     if T.ndim == 1:
         T = T.reshape(-1, 1)


### PR DESCRIPTION
macos-10.15 will soon be deprecated in GitHub Actions and Azure Devops so we are upgrading the version of macOS that we use.

Relevant issue:

https://github.com/actions/runner-images/issues/5583

Additionally updating the deprecated ubuntu 18 image to ubuntu 20.

Fixing multiple new E275 style errors with new pycodestyle update.

