### PR TITLE
add matplotlib version ceiling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,8 @@ all =
     tensorflow > 1.10, < 2.3
     ; Version capped due to tensorflow incompatibility
     protobuf < 4
-    matplotlib
+    ; Version capped due to shap incompatibility
+    matplotlib < 3.6.0
     
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,8 @@ tf =
     protobuf < 4
 plt =
     graphviz
-    matplotlib
+    ; Version capped due to shap incompatibility
+    matplotlib < 3.6.0
 dowhy = 
     dowhy < 0.9
 all =


### PR DESCRIPTION
It seems that a recently released matplotlib version has broken some things for the shap library, which in turn causes some of our tests/functionality to fail.

Capping the version to avoid for now.

Relevant issues:
https://github.com/slundberg/shap/issues/2687
https://github.com/SeldonIO/alibi/issues/774

 